### PR TITLE
singer-python 3.5.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name="tap-jira",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_jira"],
       install_requires=[
-          "singer-python==3.5.0",
+          "singer-python==3.5.4",
           "requests",
       ],
       entry_points="""


### PR DESCRIPTION
Doing so fixes a 500 we were getting from Stitch due to "$ref"s not being resolved for "patternProperties" schemas. See https://github.com/singer-io/singer-python/pull/45

Testing

- A full sync of Jira into Stitch now works