### PR TITLE
Fix pulling versions data even when not selected

### DIFF
--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -58,13 +58,13 @@ def sync(ctx):
                           if cs.is_selected()]
     streams = [s for s in streams_.all_streams[start_idx:]
                if s.tap_stream_id in stream_ids_to_sync]
-    # two loops through streams are necessary so that write_to_stdout is set
+    # two loops through streams are necessary so that selected is set
     # for all appropriate streams BEFORE syncing any streams. Otherwise, the
     # first stream might generate data for the second stream, but the second
-    # stream hasn't set write_to_stdout yet
+    # stream hasn't set selected yet
     for stream in streams:
         output_schema(stream)
-        stream.write_to_stdout = True
+        stream.selected = True
     for stream in streams:
         # indirect_stream indicates the data for the stream comes from some
         # other stream, so we don't sync it directly.

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -54,17 +54,14 @@ def sync(ctx):
     currently_syncing = ctx.state.get("currently_syncing")
     start_idx = streams_.all_stream_ids.index(currently_syncing) \
         if currently_syncing else 0
-    stream_ids_to_sync = [cs.tap_stream_id for cs in ctx.catalog.streams
-                          if cs.is_selected()]
     streams = [s for s in streams_.all_streams[start_idx:]
-               if s.tap_stream_id in stream_ids_to_sync]
-    # two loops through streams are necessary so that selected is set
-    # for all appropriate streams BEFORE syncing any streams. Otherwise, the
-    # first stream might generate data for the second stream, but the second
-    # stream hasn't set selected yet
+               if s.tap_stream_id in ctx.selected_stream_ids]
+    # two loops through streams are necessary so that the schema is output
+    # BEFORE syncing any streams. Otherwise, the first stream might generate
+    # data for the second stream, but the second stream hasn't output its
+    # schema yet
     for stream in streams:
         output_schema(stream)
-        stream.selected = True
     for stream in streams:
         # indirect_stream indicates the data for the stream comes from some
         # other stream, so we don't sync it directly.

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -9,6 +9,10 @@ class Context(object):
         self.state = state
         self.catalog = catalog
         self.client = Client(config)
+        self.selected_stream_ids = set(
+            [s.tap_stream_id for s in self.catalog.streams
+             if s.is_selected()]
+        )
 
     @property
     def bookmarks(self):

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -68,9 +68,8 @@ class Projects(Stream):
             # appears.
             project.pop("versions", None)
         self.write_page(projects)
-        if VERSIONS.tap_stream_id in ctx.selected_stream_ids:
-            for project in projects:
-                VERSIONS.sync(ctx, project=project)
+        for project in projects:
+            VERSIONS.sync(ctx, project=project)
 
 
 class Everything(Stream):
@@ -169,9 +168,8 @@ class Issues(Stream):
             comments = []
             for issue in page:
                 comments += issue["fields"].pop("comment")["comments"]
-            if ISSUE_COMMENTS.tap_stream_id in ctx.selected_stream_ids:
-                ISSUE_COMMENTS.format_comments(comments)
-                ISSUE_COMMENTS.write_page(comments)
+            ISSUE_COMMENTS.format_comments(comments)
+            ISSUE_COMMENTS.write_page(comments)
             self.format_issues(page)
             self.write_page(page)
             last_updated = page[-1]["fields"]["updated"]

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -24,13 +24,11 @@ class Stream(object):
     :var tap_stream_id:
     :var pk_fields: A list of primary key fields
     :var indirect_stream: If True, this indicates the stream cannot be synced
-    directly, but instead has its data generated via a separate stream.
-    :var selected: Must be true for this stream to sync any data."""
+    directly, but instead has its data generated via a separate stream."""
     def __init__(self, tap_stream_id, pk_fields, indirect_stream=False):
         self.tap_stream_id = tap_stream_id
         self.pk_fields = pk_fields
         self.indirect_stream = indirect_stream
-        self.selected = False
 
     def __repr__(self):
         return "<Stream(" + self.tap_stream_id + ")>"
@@ -70,7 +68,7 @@ class Projects(Stream):
             # appears.
             project.pop("versions", None)
         self.write_page(projects)
-        if VERSIONS.selected:
+        if VERSIONS.tap_stream_id in ctx.selected_stream_ids:
             for project in projects:
                 VERSIONS.sync(ctx, project=project)
 
@@ -171,7 +169,7 @@ class Issues(Stream):
             comments = []
             for issue in page:
                 comments += issue["fields"].pop("comment")["comments"]
-            if ISSUE_COMMENTS.selected:
+            if ISSUE_COMMENTS.tap_stream_id in ctx.selected_stream_ids:
                 ISSUE_COMMENTS.format_comments(comments)
                 ISSUE_COMMENTS.write_page(comments)
             self.format_issues(page)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -68,8 +68,9 @@ class Projects(Stream):
             # appears.
             project.pop("versions", None)
         self.write_page(projects)
-        for project in projects:
-            VERSIONS.sync(ctx, project=project)
+        if VERSIONS.tap_stream_id in ctx.selected_stream_ids:
+            for project in projects:
+                VERSIONS.sync(ctx, project=project)
 
 
 class Everything(Stream):
@@ -168,8 +169,9 @@ class Issues(Stream):
             comments = []
             for issue in page:
                 comments += issue["fields"].pop("comment")["comments"]
-            ISSUE_COMMENTS.format_comments(comments)
-            ISSUE_COMMENTS.write_page(comments)
+            if ISSUE_COMMENTS.tap_stream_id in ctx.selected_stream_ids:
+                ISSUE_COMMENTS.format_comments(comments)
+                ISSUE_COMMENTS.write_page(comments)
             self.format_issues(page)
             self.write_page(page)
             last_updated = page[-1]["fields"]["updated"]

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -25,24 +25,17 @@ class Stream(object):
     :var pk_fields: A list of primary key fields
     :var indirect_stream: If True, this indicates the stream cannot be synced
     directly, but instead has its data generated via a separate stream.
-    :var write_to_stdout: Must be true for this stream to output any data to
-    stdout.
-
-    .. note:: By default, :var write_to_stdout: is False. Set it to True or
-    :func:`write_page` will not output to stdout."""
+    :var selected: Must be true for this stream to sync any data."""
     def __init__(self, tap_stream_id, pk_fields, indirect_stream=False):
         self.tap_stream_id = tap_stream_id
         self.pk_fields = pk_fields
         self.indirect_stream = indirect_stream
-        self.write_to_stdout = False
+        self.selected = False
 
     def __repr__(self):
         return "<Stream(" + self.tap_stream_id + ")>"
 
     def write_page(self, page):
-        """Writes page of data to stdout when :var write_to_stdout: is True."""
-        if not self.write_to_stdout:
-            return
         singer.write_records(self.tap_stream_id, page)
         with metrics.record_counter(self.tap_stream_id) as counter:
             counter.increment(len(page))
@@ -77,8 +70,9 @@ class Projects(Stream):
             # appears.
             project.pop("versions", None)
         self.write_page(projects)
-        for project in projects:
-            VERSIONS.sync(ctx, project=project)
+        if VERSIONS.selected:
+            for project in projects:
+                VERSIONS.sync(ctx, project=project)
 
 
 class Everything(Stream):
@@ -177,8 +171,9 @@ class Issues(Stream):
             comments = []
             for issue in page:
                 comments += issue["fields"].pop("comment")["comments"]
-            ISSUE_COMMENTS.format_comments(comments)
-            ISSUE_COMMENTS.write_page(comments)
+            if ISSUE_COMMENTS.selected:
+                ISSUE_COMMENTS.format_comments(comments)
+                ISSUE_COMMENTS.write_page(comments)
             self.format_issues(page)
             self.write_page(page)
             last_updated = page[-1]["fields"]["updated"]


### PR DESCRIPTION
The versions endpoint depends on the projects endpoint. So when projects are pulled, each project is fed into the version stream, which then pulls all the versions for that project. The way it had been written, if projects were selected, but versions were not, data for versions would still be pulled (they just wouldn't be written to stdout). This fixes that by getting versions to only pull data when necessary.

The flip side of this is that currently, if versions are selected, but projects are not, then no data will be synced. I assume this is undesired. If so let me know and I can fix.