### PR TITLE
safety check attachments key before looping

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -157,7 +157,7 @@ class Issues(Stream):
             format_dt(fields, "updated")
             format_dt(fields, "created")
             format_dt(fields, "lastViewed")
-            for att in fields["attachment"]:
+            for att in fields.get("attachment", []):
                 format_dt(att, "created")
             fields.pop("worklog", None)
             # The JSON schema for the search endpoint indicates an "operations"


### PR DESCRIPTION
Fix KeyError in case the `attachments` property is absent from the issue. 