### PR TITLE
Link changelog to issue

### DIFF
--- a/tap_jira/schemas/changelogs.json
+++ b/tap_jira/schemas/changelogs.json
@@ -8,6 +8,12 @@
         "string"
       ]
     },
+    "issueId": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "author": {
       "title": "User",
       "type": [

--- a/tap_jira/schemas/issue_comments.json
+++ b/tap_jira/schemas/issue_comments.json
@@ -8,6 +8,9 @@
     "id": {
       "type": ["null", "string"]
     },
+    "issueId": {
+      "type": ["null","string"]
+    },
     "author": {
       "$ref": "user"
     },

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -178,13 +178,13 @@ class Issues(Stream):
         for page in pager.pages(self.tap_stream_id,
                                 "GET", "/rest/api/2/search",
                                 params=params):
-            # comments and changelogs are extracted before writing the page 
+            # comments and changelogs are extracted before writing the page
             # because the "pop" removes these fields from each issue
             comments = []
             changelogs = []
             for issue in page:
                 issue_changelogs = issue.pop("changelog")["histories"]
-                # add issue ID to the changelog so it can be linked back to 
+                # add issue ID to the changelog so it can be linked back to
                 # its parent issue
                 for issue_changelog in issue_changelogs:
                     issue_changelog["issueId"] = issue["id"]

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -185,7 +185,6 @@ class Issues(Stream):
             # sync issues
             self.format_issues(page)
             self.write_page(page)
-
             last_updated = page[-1]["fields"]["updated"]
             ctx.set_bookmark(page_num_offset, pager.next_page_num)
             ctx.write_state()

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -178,10 +178,17 @@ class Issues(Stream):
         for page in pager.pages(self.tap_stream_id,
                                 "GET", "/rest/api/2/search",
                                 params=params):
-            # comments are extracted before writing the page because the "pop"
-            # removes the "comment" field from each issue
+            # comments and changelogs are extracted before writing the page 
+            # because the "pop" removes these fields from each issue
             comments = []
+            changelogs = []
             for issue in page:
+                issue_changelogs = issue.pop("changelog")["histories"]
+                # add issue ID to the changelog so it can be linked back to 
+                # its parent issue
+                for issue_changelog in issue_changelogs:
+                    issue_changelog["issueId"] = issue["id"]
+                changelogs += issue_changelogs
                 comments += issue["fields"].pop("comment")["comments"]
             self.format_issues(page)
             self.write_page(page)


### PR DESCRIPTION
Fixes a bug where, when a group of Issues were returned by a JIRA API query, only the changelogs for the last Issue were sync'd.  

Also adds the issueId field to changelogs so they can be linked to their parent Issue.  This was requested in [10](https://github.com/singer-io/tap-jira/issues/10)