### PR TITLE
add json-type into schema for issue transitions

### DIFF
--- a/tap_jira/schemas/issue_transitions.json
+++ b/tap_jira/schemas/issue_transitions.json
@@ -126,6 +126,28 @@
       "required": [
         "required"
       ]
+    },
+    "json-type": {
+      "title": "Json Type",
+      "type": ["null", "object"],
+      "properties": {
+        "type": {
+          "type": ["null", "string"]
+        },
+        "items": {
+          "type": ["null", "string"]
+        },
+        "system": {
+          "type": ["null", "string"]
+        },
+        "custom": {
+          "type": ["null", "string"]
+        },
+        "customId": {
+          "type": ["null", "integer"]
+        }
+      },
+      "additionalProperties": false
     }
   }
 }


### PR DESCRIPTION
#12 broke the tap - I had an old version of tap-jira installed in my virtualenv. Recreating the virtualenv and then running the tap caused it to fail. This change fixes the issue.