### PR TITLE
Use maxResults to set the startAt for the next page

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -92,6 +92,6 @@ class Paginator(object):
             if len(page) < response["maxResults"]:
                 self.next_page_num = None
             else:
-                self.next_page_num += 1
+                self.next_page_num += response["maxResults"]
             if page:
                 yield page


### PR DESCRIPTION
The startAt is an 0 based index value. Previously the code was returning issues multiple times and operating too slowly.

