### PR TITLE
Adding timezone to Issues queries

### DIFF
--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -42,3 +42,8 @@ class Context(object):
 
     def write_state(self):
         singer.write_state(self.state)
+
+    def retrieve_timezone(self):
+        response = self.client.send("GET", "/rest/api/2/myself")
+        response.raise_for_status()
+        return response.json()["timeZone"]

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1,4 +1,5 @@
 import json
+import pytz
 import singer
 from singer import metrics
 from singer.utils import strftime
@@ -178,8 +179,9 @@ class Issues(Stream):
         updated_bookmark = [self.tap_stream_id, "updated"]
         page_num_offset = [self.tap_stream_id, "offset", "page_num"]
         last_updated = ctx.update_start_date_bookmark(updated_bookmark)
-        start_date = pendulum.parse(last_updated).date().isoformat()
-        jql = "updated >= {} order by updated asc".format(start_date)
+        timezone = ctx.retrieve_timezone()
+        start_date = pendulum.parse(last_updated).astimezone(pytz.timezone(timezone)).strftime("%Y-%m-%d %H:%M")
+        jql = "updated >= '{}' order by updated asc".format(start_date)
         params = {"fields": "*all",
                   "expand": "changelog,transitions",
                   "validateQuery": "strict",


### PR DESCRIPTION
We've had some reports of missing data when using this tap consistently, this is an attempt to address an issue with how timezones are handled for the issues stream to avoid a possible cause.

The idea behind this is that the *Issues* stream requests using the `search` endpoint with JQL of `updated >= <bookmark_date>`. The problem here is twofold:

1. The `search` API, when queried by authorized users, uses the user's configured timezone to treat datetimes, [according to this Jira forum post](https://community.atlassian.com/t5/Jira-questions/JIRA-API-JQL-datetime-format-does-not-have-timezone/qaq-p/870844).
    - So the bookmark that we're using is assumed by us to be in UTC, but Jira assumes it to be in, for example, "America/New_York".
2. The JQL parameter is just the ***date*** of the bookmark.
    - Though, the API accepts datetime values formatted as `YYYY-mm-dd HH:MM`, in the user's timezone.

Given these two things, the problem that can arise is that the user's timezone is `UTC-minus-X` hours, which means that the state's UTC bookmark will be `X` hours ahead of Jira's sense of time when querying. When we get within this window towards the end of the day, the date filter will jump to the next day, and the tap will miss any updates that happened in that window.

I ran a couple of tests and confirmed that the API behaved as though it was expecting `America/New_York` time when it received UTC time. This is the first pass at implementing this.