### PR TITLE
use a different endpoint for users

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,9 @@ jobs:
       - run:
           name: 'Setup virtual env'
           command: |
-            virtualenv -p python3 /usr/local/share/virtualenvs/tap-jira
+            python3 -mvenv /usr/local/share/virtualenvs/tap-jira
             source /usr/local/share/virtualenvs/tap-jira/bin/activate
+            pip install -U 'pip<19.2' setuptools
             pip install -e .[dev]
       - run:
           name: 'Unit Tests'

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -170,8 +170,6 @@ class Paginator():
 
             # Accounts for responses that don't nest their results in a
             # key by falling back to the params `maxResults` setting.
-            # `Users` is an example of a stream that does not nest its
-            # results.
             if 'maxResults' in response:
                 max_results = response['maxResults']
             else:

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -146,14 +146,13 @@ class ProjectTypes(Stream):
 class Users(Stream):
     def sync(self):
         max_results = 2
-        params = {"username": "%",
-                  "includeInactive": "true",
+        params = {"groupname": "jira-software-users",
                   "maxResults": max_results}
         page_num_offset = [self.tap_stream_id, "offset", "page_num"]
         page_num = Context.bookmark(page_num_offset) or 0
-        pager = Paginator(Context.client, items_key=None, page_num=page_num)
+        pager = Paginator(Context.client, items_key='values', page_num=page_num)
         for page in pager.pages(self.tap_stream_id, "GET",
-                                "/rest/api/2/user/search",
+                                "/rest/api/2/group/member",
                                 params=params):
             self.write_page(page)
             Context.set_bookmark(page_num_offset, pager.next_page_num)


### PR DESCRIPTION
An API update broke the prior behavior because `%` was no longer being considered a wildcard. Our tests caught this. Fortunately there's a different endpoint that returns the same data.