### PR TITLE
Configurable groups list

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -7,6 +7,7 @@ from singer import metrics, utils, metadata, Transformer
 from .http import Paginator
 from .context import Context
 
+
 def raise_if_bookmark_cannot_advance(worklogs):
     # Worklogs can only be queried with a `since` timestamp and
     # provides no way to page through the results. The `since`

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -5,7 +5,6 @@ import requests
 from singer import metrics, utils, metadata, Transformer
 from .http import Paginator
 from .context import Context
-import pprint
 
 def raise_if_bookmark_cannot_advance(worklogs):
     # Worklogs can only be queried with a `since` timestamp and

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1,10 +1,11 @@
 import json
 import pytz
 import singer
+import requests
 from singer import metrics, utils, metadata, Transformer
 from .http import Paginator
 from .context import Context
-
+import pprint
 
 def raise_if_bookmark_cannot_advance(worklogs):
     # Worklogs can only be queried with a `since` timestamp and
@@ -146,19 +147,30 @@ class ProjectTypes(Stream):
 class Users(Stream):
     def sync(self):
         max_results = 2
-        params = {"groupname": "jira-software-users",
-                  "maxResults": max_results}
-        page_num_offset = [self.tap_stream_id, "offset", "page_num"]
-        page_num = Context.bookmark(page_num_offset) or 0
-        pager = Paginator(Context.client, items_key='values', page_num=page_num)
-        for page in pager.pages(self.tap_stream_id, "GET",
-                                "/rest/api/2/group/member",
-                                params=params):
-            self.write_page(page)
-            Context.set_bookmark(page_num_offset, pager.next_page_num)
-            singer.write_state(Context.state)
-        Context.set_bookmark(page_num_offset, None)
-        singer.write_state(Context.state)
+
+        if Context.config.get("groups"):
+            groups = Context.config.get("groups").split(",")
+        else:
+            groups = ["jira-administrators",
+                      "jira-software-users",
+                      "jira-core-users",
+                      "jira-users",
+                      "users"]
+
+        for group in groups:
+            try:
+                params = {"groupname": group,
+                          "maxResults": max_results}
+                pager = Paginator(Context.client, items_key='values')
+                for page in pager.pages(self.tap_stream_id, "GET",
+                                        "/rest/api/2/group/member",
+                                        params=params):
+                    self.write_page(page)
+            except requests.exceptions.HTTPError as http_error:
+                if http_error.response.status_code == 404:
+                    LOGGER.info("Could not find group \"%s\", skipping", group)
+                else:
+                    raise http_error
 
 
 class Issues(Stream):

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1,7 +1,8 @@
 import json
 import pytz
-import singer
 import requests
+import singer
+
 from singer import metrics, utils, metadata, Transformer
 from .http import Paginator
 from .context import Context


### PR DESCRIPTION
Search for users in all of the default groups described [here](https://confluence.atlassian.com/adminjiraserver/managing-groups-938847035.html), plus `users`, skipping any that don't exist.

Allow the list of groups to search to be overridden with the `groups` config parameter, specified as a CSV.

