### PR TITLE
Update schemas

### DIFF
--- a/tap_jira/schemas/changelogs.json
+++ b/tap_jira/schemas/changelogs.json
@@ -145,6 +145,18 @@
               "null",
               "string"
             ]
+          },
+          "tmpFromAccountId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tmpToAccountId": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       }

--- a/tap_jira/schemas/changelogs.json
+++ b/tap_jira/schemas/changelogs.json
@@ -45,6 +45,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",

--- a/tap_jira/schemas/issue_comments.json
+++ b/tap_jira/schemas/issue_comments.json
@@ -141,6 +141,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",

--- a/tap_jira/schemas/issues.json
+++ b/tap_jira/schemas/issues.json
@@ -388,6 +388,12 @@
                 "string"
               ]
             },
+            "accountType": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "active": {
               "type": [
                 "null",

--- a/tap_jira/schemas/projects.json
+++ b/tap_jira/schemas/projects.json
@@ -307,6 +307,39 @@
         "null",
         "string"
       ]
+    },
+    "entityId": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "uuid": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "properties": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "patternProperties": {
+        ".+": {}
+      }
+    },
+    "isPrivate": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "style": {
+      "type": [
+        "null",
+        "string"
+      ]
     }
   },
   "definitions": {

--- a/tap_jira/schemas/projects.json
+++ b/tap_jira/schemas/projects.json
@@ -385,6 +385,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "name": {
           "type": [
             "null",

--- a/tap_jira/schemas/users.json
+++ b/tap_jira/schemas/users.json
@@ -24,6 +24,12 @@
         "string"
       ]
     },
+    "accountType": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "name": {
       "type": [
         "null",

--- a/tap_jira/schemas/worklogs.json
+++ b/tap_jira/schemas/worklogs.json
@@ -149,6 +149,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",


### PR DESCRIPTION
* Add an `accountType` property on user/author
* Add `tmpFromAccountId` and `tmpToAccountId` properties to changelogs
* Add `entityId`, `uuid`, `properties`, `isPrivate` and `style` properties to projects schema

So that the tap is compliant with the latest JIRA REST API specs and the output of the tap is less verbose (no more "removed fields" message from the Transformer)