### PR TITLE
Removing groups and applicationRoles from users schema

### DIFF
--- a/tap_jira/schemas/users.json
+++ b/tap_jira/schemas/users.json
@@ -75,68 +75,11 @@
         "string"
       ]
     },
-    "groups": {
-      "$ref": "simple-list-wrapper"
-    },
-    "applicationRoles": {
-      "$ref": "simple-list-wrapper"
-    },
     "expand": {
       "type": [
         "null",
         "string"
       ]
-    }
-  },
-  "definitions": {
-    "simple-list-wrapper": {
-      "title": "Simple List Wrapper",
-      "type": [
-        "null",
-        "object"
-      ],
-      "properties": {
-        "size": {
-          "type": [
-            "null",
-            "integer"
-          ]
-        },
-        "max-results": {
-          "type": [
-            "null",
-            "integer"
-          ]
-        },
-        "items": {
-          "type": [
-            "null",
-            "array"
-          ],
-          "items": {
-            "title": "Group",
-            "type": [
-              "null",
-              "object"
-            ],
-            "properties": {
-              "name": {
-                "type": [
-                  "null",
-                  "string"
-                ]
-              },
-              "self": {
-                "type": [
-                  "null",
-                  "string"
-                ],
-                "format": "uri"
-              }
-            }
-          }
-        }
-      }
     }
   }
 }

--- a/tap_jira/schemas/users.json
+++ b/tap_jira/schemas/users.json
@@ -69,7 +69,7 @@
         "string"
       ]
     },
-    "locale": {
+    "accountType": {
       "type": [
         "null",
         "string"


### PR DESCRIPTION
The endpoint as-is will not return these values. Syncing this data from Users would take a fundamental change in how the tap requests Users, so the fields are being removed.

This PR also updates the `users` schema to match the `UserDetails` object described under the `PageBeanUserDetails` response object in `Groups` -> `Get users from groups` [here](https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-group-member-get)

**More Info**

The tap currently syncs users based on group using the `group/member` endpoint and values that are specified in the config, or a constant list [here](https://github.com/singer-io/tap-jira/blob/master/tap_jira/streams.py#L155-L159). According to the Jira API documentation, this returns a `UserDetails` object.

The `groups` and `applicationRoles` data exists on the `/user` endpoint ([docs](https://developer.atlassian.com/cloud/jira/platform/rest/v3/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#api-rest-api-3-user-get), `Users` -> `Get Users` on left hand menu). Since this can only get one user, it'd require a redesign to get the data efficiently.