### PR TITLE
Update key property for stream users

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -281,7 +281,7 @@ ALL_STREAMS = [
     Stream("project_categories", ["id"], path="/rest/api/2/projectCategory"),
     Stream("resolutions", ["id"], path="/rest/api/2/resolution"),
     Stream("roles", ["id"], path="/rest/api/2/role"),
-    Users("users", ["key"]),
+    Users("users", ["accountId"]),
     ISSUES,
     ISSUE_COMMENTS,
     CHANGELOGS,

--- a/tests/spec.py
+++ b/tests/spec.py
@@ -73,6 +73,10 @@ class TapSpec():
             self.PRIMARY_KEYS: {"key"},
         }
 
+        account_id_pk = {
+            self.PRIMARY_KEYS: {"accountId"},
+        }
+
         return {
             "projects": id_pk,
             "project_types": key_pk,
@@ -80,7 +84,7 @@ class TapSpec():
             "versions": id_pk,
             "resolutions": id_pk,
             "roles": id_pk,
-            "users": key_pk,
+            "users": account_id_pk,
             "issues": id_pk,
             "issue_comments": id_pk,
             "issue_transitions": id_pk,


### PR DESCRIPTION
# Description of change
The tap currently uses a deprecated field as the `key_property` https://developer.atlassian.com/cloud/jira/platform/deprecation-notice-user-privacy-api-migration-guide/#user.

This PR follows the migration guide to use `accountId` instead

# Manual QA steps
 - Ran syncs and confirmed that the target no longer complains
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
