### PR TITLE
remove duplicate names, put create connection back in tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     docker:
-      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:tap-tester-v4
+      - image: 218546966473.dkr.ecr.us-east-1.amazonaws.com/circle-ci:stitch-tap-tester
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,85 +42,43 @@ jobs:
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-jira \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_discovery.py
+            run-test --tap=tap-jira tests/test_discovery.py
       - run:
           name: 'Test Full Replication'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-jira \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_full_replication.py
+            run-test --tap=tap-jira tests/test_full_replication.py
       - run:
           name: 'Test Custom Groups'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-jira \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_custom_groups.py
+            run-test --tap=tap-jira tests/test_custom_groups.py
       - run:
           name: 'Test Bookmarks'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-jira \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_bookmarks.py
+            run-test --tap=tap-jira tests/test_bookmarks.py
       - run:
           name: 'Test Start Date'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-jira \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_start_date.py
+            run-test --tap=tap-jira tests/test_start_date.py
       - run:
           name: 'Test Automatic Fields'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-jira \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_automatic_fields.py
+            run-test --tap=tap-jira tests/test_automatic_fields.py
       - run:
           name: 'Test Pagination'
           command: |
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-test --tap=tap-jira \
-                     --target=target-stitch \
-                     --orchestrator=stitch-orchestrator \
-                     --email=harrison+sandboxtest@stitchdata.com \
-                     --password=$SANDBOX_PASSWORD \
-                     --client-id=50 \
-                     tests/test_pagination.py
+            run-test --tap=tap-jira tests/test_pagination.py
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -21,11 +21,6 @@ class BaseTapTest(TapSpec, unittest.TestCase):
     Run discovery for as a prerequisite for most tests
     """
 
-    @staticmethod
-    def name():
-        """The name of the test within the suite"""
-        return "test_name"
-
     def environment_variables(self):
         return ({p for p in self.CONFIGURATION_ENVIRONMENT['properties'].values()} |
                 {c for c in self.CONFIGURATION_ENVIRONMENT['credentials'].values()})
@@ -107,23 +102,11 @@ class BaseTapTest(TapSpec, unittest.TestCase):
         if missing_envs:
             raise Exception("Missing test-required environment variables: {}".format(missing_envs))
 
-    def test_run(self):
-        """
-        Default Test Setup
-        Remove previous connections (with the same name)
-        Create a new connection (with the properties and credentials above)
-        Run discovery and ensure it completes successfully
-        """
-        self.do_test(self.create_connection())
-
-    def do_test(self, conn_id):
-        """A placeholder test to override in sub-class tests"""
-
     #########################
     #   Helper Methods      #
     #########################
 
-    def create_connection(self, original_properties: bool = True):
+    def create_connection_with_initial_discovery(self, original_properties: bool = True):
         """Create a new connection with the test name"""
         # Create the connection
         conn_id = connections.ensure_connection(self, original_properties)

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -10,9 +10,9 @@ class MinimumSelectionTest(BaseTapTest):
     """Test that with no fields selected for a stream automatic fields are still replicated"""
 
     def name(self):
-        return "tap_tester_tap_jira_no_fields_test"
+        return "tt_jira_no_fields_test"
 
-    def do_test(self, conn_id):
+    def test_run(self):
         """
         Verify that for each stream you can get multiple pages of data
         when no fields are selected and only the automatic fields are replicated.
@@ -22,6 +22,8 @@ class MinimumSelectionTest(BaseTapTest):
         fetch of data.  For instance if you have a limit of 250 records ensure
         that 251 (or more) records have been posted for that stream.
         """
+        conn_id = self.create_connection_with_initial_discovery()
+
         self.create_test_data()
 
         # Select all streams and no fields within streams

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -3,7 +3,6 @@ Test that with no fields selected for a stream automatic fields are still replic
 """
 
 from tap_tester import runner, menagerie
-from tap_tester.scenario import SCENARIOS
 from base import BaseTapTest
 
 class MinimumSelectionTest(BaseTapTest):
@@ -55,6 +54,3 @@ class MinimumSelectionTest(BaseTapTest):
                     actual_fields_by_stream.get(stream, set()),
                     expected_fields_for_stream,
                     msg="The fields sent to the target are not the automatic fields.\nExpected: {}\nActual: {}".format(expected_fields_for_stream, actual_fields_by_stream.get(stream, set())))
-
-
-SCENARIOS.add(MinimumSelectionTest)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -6,7 +6,6 @@ from datetime import datetime as dt
 from dateutil.parser import parse
 
 from tap_tester import menagerie, runner
-from tap_tester.scenario import SCENARIOS
 
 from base import BaseTapTest
 
@@ -142,6 +141,3 @@ class BookmarkTest(BaseTapTest):
                 # verify that the minimum bookmark sent to the target for the second sync
                 # is greater than or equal to the bookmark from the first sync
                 self.assertGreaterEqual(target_value, state_value)
-
-
-SCENARIOS.add(BookmarkTest)

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -14,9 +14,9 @@ class BookmarkTest(BaseTapTest):
     """Test tap sets a bookmark and respects it for the next sync of a stream"""
 
     def name(self):
-        return "tap_tester_tap_jira_bookmark_test"
+        return "tt_jira_bookmark_test"
 
-    def do_test(self, conn_id):
+    def test_run(self):
         """
         Verify that for each stream you can do a sync which records bookmarks.
         That the bookmark is the maximum value sent to the target for the replication key.
@@ -33,6 +33,8 @@ class BookmarkTest(BaseTapTest):
         For EACH stream that is incrementally replicated there are multiple rows of data with
             different values for the replication key
         """
+        conn_id = self.create_connection_with_initial_discovery()
+
         # Select all streams and no fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         incremental_streams = {key for key, value in self.expected_replication_method().items()

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -3,7 +3,6 @@ Test that with no fields selected for a stream automatic fields are still replic
 """
 
 from tap_tester import runner, menagerie
-from tap_tester.scenario import SCENARIOS
 from base import BaseTapTest
 
 class CustomGroupsTest(BaseTapTest):
@@ -36,6 +35,3 @@ class CustomGroupsTest(BaseTapTest):
             record_count_by_stream.get("users", 0),
             0,
             msg="Expected zero users records because we used garbage group names")
-
-    
-SCENARIOS.add(CustomGroupsTest)

--- a/tests/test_custom_groups.py
+++ b/tests/test_custom_groups.py
@@ -10,18 +10,20 @@ class CustomGroupsTest(BaseTapTest):
     """Test that custom groups are used if provided"""
 
     def name(self):
-        return "tap_tester_tap_jira_no_fields_test"
+        return "tt_jira_custom_fields_test"
 
     def get_properties(self, original: bool = True):
         return_value = super().get_properties(original)
         return_value["groups"] = "doesnotexist,reallydoesnotexist"
         return return_value
 
-    def do_test(self, conn_id):
+    def test_run(self):
         """
         Test assumes that the test account has at least one user that doesn't exist
         in the groups returned by the get_properties function above
         """
+        conn_id = self.create_connection_with_initial_discovery()
+
         found_catalogs = menagerie.get_catalogs(conn_id)
         user_catalog = list(filter(lambda x: x["stream_name"] == "users", found_catalogs))
 

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -13,9 +13,9 @@ class DiscoveryTest(BaseTapTest):
     """ Test the tap discovery """
 
     def name(self):
-        return "tap_tester_tap_jira_discovery_test"
+        return "tt_jira_discovery_test"
 
-    def do_test(self, conn_id):
+    def test_run(self):
         """
         Verify that discover creates the appropriate catalog, schema, metadata, etc.
 
@@ -32,6 +32,7 @@ class DiscoveryTest(BaseTapTest):
           are given the inclusion of automatic (metadata and annotated schema).
         • verify that all other fields have inclusion of available (metadata and schema)
         """
+        conn_id = self.create_connection_with_initial_discovery()
 
         # Verify number of actual streams discovered match expected
         found_catalogs = menagerie.get_catalogs(conn_id)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -5,7 +5,6 @@ import re
 
 from tap_tester import menagerie
 
-from tap_tester.scenario import SCENARIOS
 from base import BaseTapTest
 
 
@@ -163,6 +162,3 @@ class DiscoveryTest(BaseTapTest):
                          and item.get("breadcrumb", ["properties", None])[1]
                          not in actual_automatic_fields}),
                     msg="Not all non key properties are set to available in metadata")
-
-
-SCENARIOS.add(DiscoveryTest)

--- a/tests/test_full_replication.py
+++ b/tests/test_full_replication.py
@@ -13,9 +13,9 @@ class FullReplicationTest(BaseTapTest):
     """Test tap gets all records for streams with full replication"""
 
     def name(self):
-        return "tap_tester_tap_name_full_test"
+        return "tt_name_full_test"
 
-    def do_test(self, conn_id):
+    def test_run(self):
         """
         Verify that a bookmark doesn't exist for the stream
         Verify that the second sync includes the same number or more records than the first sync
@@ -26,6 +26,8 @@ class FullReplicationTest(BaseTapTest):
         For EACH stream that is fully replicated there are multiple rows of data with
             different values for the replication key
         """
+        conn_id = self.create_connection_with_initial_discovery()
+
         # Select all streams and no fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
         full_streams = {key for key, value in self.expected_replication_method().items()

--- a/tests/test_full_replication.py
+++ b/tests/test_full_replication.py
@@ -5,7 +5,6 @@ import json
 
 from tap_tester import menagerie, runner
 
-from tap_tester.scenario import SCENARIOS
 from base import BaseTapTest
 
 
@@ -92,6 +91,3 @@ class FullReplicationTest(BaseTapTest):
 
                 self.assertEqual(len(first_data), same_records,
                                  msg="Not all data from the first sync was in the second sync")
-
-
-SCENARIOS.add(FullReplicationTest)

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -11,9 +11,9 @@ class PaginationTest(BaseTapTest):
     """ Test the tap pagination to get multiple pages of data """
 
     def name(self):
-        return "tap_tester_tap_jira_pagination_test"
+        return "tt_jira_pagination_test"
 
-    def do_test(self, conn_id):
+    def test_run(self):
         """
         Verify that for each stream you can get multiple pages of data
         and that when all fields are selected more than the automatic fields are replicated.
@@ -23,6 +23,8 @@ class PaginationTest(BaseTapTest):
         fetch of data.  For instance if you have a limit of 250 records ensure
         that 251 (or more) records have been posted for that stream.
         """
+        conn_id = self.create_connection_with_initial_discovery()
+
         self.create_test_data()
 
         # Select all streams and all fields within streams

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -3,7 +3,6 @@ Test tap pagination of streams
 """
 from tap_tester import menagerie, runner
 
-from tap_tester.scenario import SCENARIOS
 from base import BaseTapTest
 
 
@@ -63,6 +62,3 @@ class PaginationTest(BaseTapTest):
                         self.expected_foreign_keys().get(stream, set())),
                     msg="The fields sent to the target don't include non-automatic fields"
                 )
-
-
-SCENARIOS.add(PaginationTest)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -8,7 +8,6 @@ from dateutil.parser import parse
 
 from tap_tester import menagerie, runner
 
-from tap_tester.scenario import SCENARIOS
 from base import BaseTapTest
 
 
@@ -120,5 +119,3 @@ class StartDateTest(BaseTapTest):
                         print("bookmarks cannot be converted to dates, "
                               "can't test start_date for {}".format(stream))
 
-
-SCENARIOS.add(StartDateTest)

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -25,10 +25,12 @@ class StartDateTest(BaseTapTest):
     """
 
     def name(self):
-        return "tap_tester_tap_jira_start_date_test"
+        return "tt_jira_start_date_test"
 
-    def do_test(self, conn_id):
+    def test_run(self):
         """Test we get a lot of data back based on the start date configured in base"""
+
+        conn_id = self.create_connection_with_initial_discovery()
 
         # Select all streams and all fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
@@ -71,7 +73,7 @@ class StartDateTest(BaseTapTest):
         self.start_date = self.local_to_utc(largest_bookmark).strftime(self.START_DATE_FORMAT)
 
         # create a new connection with the new start_date
-        conn_id = self.create_connection(original_properties=False)
+        conn_id = self.create_connection_with_initial_discovery(original_properties=False)
 
         # Select all streams and all fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)


### PR DESCRIPTION
# Description of change
Rename duplicate test names, remove do_test pattern.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
