### PR TITLE
Tdl 14625 retry on 503 service unavailable

### DIFF
--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -105,7 +105,8 @@ def sync():
     singer.write_state(Context.state)
 
 
-def main_impl():
+@singer.utils.handle_top_exception(LOGGER)
+def main():
     args = get_args()
 
     # Setup Context
@@ -127,12 +128,6 @@ def main_impl():
         if Context.client and Context.client.login_timer:
             Context.client.login_timer.cancel()
 
-def main():
-    try:
-        main_impl()
-    except Exception as exc:
-        LOGGER.critical(exc)
-        raise exc
 
 if __name__ == "__main__":
     main()

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from singer import utils, metadata
+from .http import check_status
 
 
 class Context():
@@ -56,5 +57,5 @@ class Context():
     @classmethod
     def retrieve_timezone(cls):
         response = cls.client.send("GET", "/rest/api/2/myself")
-        response.raise_for_status()
+        check_status(response)
         return response.json()["timeZone"]

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -2,15 +2,13 @@ from datetime import datetime, timedelta
 import time
 import threading
 import re
+from json.decoder import JSONDecodeError
 from requests.exceptions import HTTPError
 from requests.auth import HTTPBasicAuth
 import requests
 from singer import metrics
 import singer
 import backoff
-
-class RateLimitException(Exception):
-    pass
 
 # Jira OAuth tokens last for 3600 seconds. We set it to 3500 to try to
 # come in under the limit.
@@ -110,7 +108,7 @@ def check_status(response):
     # Forming a response message for raising custom exception
     try:
         response_json = response.json()
-    except Exception:
+    except JSONDecodeError:
         response_json = {}
     if response.status_code != 200:
         message = "HTTP-error-code: {}, Error: {}".format(

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -45,7 +45,7 @@ class JiraBadGateway(JiraError):
     pass
 
 
-class JiraNotFoundError(JiraError):
+class JiraNotFoundError(JiraBackoffError):
     pass
 
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -104,8 +104,8 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     500: {
         "raise_exception": JiraInternalServerError,
-        "message": "The server encountered an unexpected condition which prevented \
-            it from fulfilling the request."
+        "message": "The server encountered an unexpected condition which prevented" \
+            " it from fulfilling the request."
     },
     501: {
         "raise_exception": JiraNotImplementedError,

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -23,6 +23,46 @@ TIME_BETWEEN_REQUESTS = timedelta(microseconds=10e3)
 
 LOGGER = singer.get_logger()
 
+class JiraError(Exception):
+    def __init__(self, message=None, response=None):
+        super().__init__(message)
+        self.message = message
+        self.response = response
+
+class JiraBackoffError(JiraError):
+    pass
+
+class JiraBadRequestError(JiraError):
+    pass
+
+
+class JiraUnauthorizedError(JiraError):
+    pass
+
+
+class JiraForbiddenError(JiraError):
+    pass
+
+
+class JiraBadGateway(JiraError):
+    pass
+
+
+class JiraNotFoundError(JiraError):
+    pass
+
+
+class JiraRateLimitError(JiraBackoffError):
+    pass
+
+
+class JiraServiceUnavailableError(JiraBackoffError):
+    pass
+
+
+class JiraGatewayTimeout(JiraError):
+    pass
+
 def should_retry_httperror(exception):
     """ Retry 500-range errors. """
     # An ConnectionError is thrown without a response
@@ -31,6 +71,40 @@ def should_retry_httperror(exception):
 
     return 500 <= exception.response.status_code < 600
 
+ERROR_CODE_EXCEPTION_MAPPING = {
+    400: {
+        "raise_exception": JiraBadRequestError,
+        "message": "A validation exception has occurred."
+    },
+    401: {
+        "raise_exception": JiraUnauthorizedError,
+        "message": "Invalid authorization credentials."
+    },
+    403: {
+        "raise_exception": JiraForbiddenError,
+        "message": "User doesn't have permission to access the resource."
+    },
+    404: {
+        "raise_exception": JiraNotFoundError,
+        "message": "The resource you have specified cannot be found."
+    },
+    429: {
+        "raise_exception": JiraRateLimitError,
+        "message": "The API rate limit for your organisation/application pairing has been exceeded."
+    },
+    502: {
+        "raise_exception": JiraBadGateway,
+        "message": "Server received an invalid response."
+    },
+    503: {
+        "raise_exception": JiraServiceUnavailableError,
+        "message": "API service is currently unavailable."
+    },
+    504: {
+        "raise_exception": JiraGatewayTimeout,
+        "message": "API service time out, please check Jira server."
+    }
+}
 
 class Client():
     def __init__(self, config):
@@ -104,7 +178,7 @@ class Client():
         return self.session.send(request.prepare())
 
     @backoff.on_exception(backoff.constant,
-                          RateLimitException,
+                          JiraBackoffError,
                           max_tries=10,
                           interval=60)
     def request(self, tap_stream_id, *args, **kwargs):
@@ -115,10 +189,24 @@ class Client():
             response = self.send(*args, **kwargs)
             self.next_request_at = datetime.now() + TIME_BETWEEN_REQUESTS
             timer.tags[metrics.Tag.http_status_code] = response.status_code
-        if response.status_code == 429:
-            raise RateLimitException()
-        response.raise_for_status()
+        self.check_status(response)
         return response.json()
+
+    def check_status(self, response):
+        # Forming a response message for raising custom exception
+        try:
+            response_json = response.json()
+        except Exception:
+            response_json = {}
+        if response.status_code != 200:
+            message = "HTTP-error-code: {}, Error: {}".format(
+                response.status_code,
+                response_json.get("status", ERROR_CODE_EXCEPTION_MAPPING.get(
+                    response.status_code, {})).get("message", "Unknown Error")
+            )
+            exc = ERROR_CODE_EXCEPTION_MAPPING.get(
+                response.status_code, {}).get("raise_exception", JiraError)
+            raise exc(message, response) from None
 
     def refresh_credentials(self):
         body = {"grant_type": "refresh_token",

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -104,7 +104,8 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     500: {
         "raise_exception": JiraInternalServerError,
-        "message": "The server encountered an unexpected condition which prevented it from fulfilling the request."
+        "message": "The server encountered an unexpected condition which prevented \
+            it from fulfilling the request."
     },
     501: {
         "raise_exception": JiraNotImplementedError,

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -32,10 +32,8 @@ class JiraBackoffError(JiraError):
 class JiraBadRequestError(JiraError):
     pass
 
-
 class JiraUnauthorizedError(JiraError):
     pass
-
 
 class JiraForbiddenError(JiraError):
     pass
@@ -43,26 +41,28 @@ class JiraForbiddenError(JiraError):
 class JiraSubRequestFailedError(JiraError):
     pass
 
-class JiraBadGateway(JiraError):
+class JiraBadGatewayError(JiraError):
     pass
 
 class JiraConflictError(JiraError):
     pass
 
-
 class JiraNotFoundError(JiraError):
     pass
-
 
 class JiraRateLimitError(JiraBackoffError):
     pass
 
-
 class JiraServiceUnavailableError(JiraBackoffError):
     pass
 
+class JiraGatewayTimeoutError(JiraError):
+    pass
 
-class JiraGatewayTimeout(JiraError):
+class JiraInternalServerError(JiraError):
+    pass
+
+class JiraNotImplementedError(JiraError):
     pass
 
 def should_retry_httperror(exception):
@@ -102,8 +102,16 @@ ERROR_CODE_EXCEPTION_MAPPING = {
         "raise_exception": JiraSubRequestFailedError,
         "message": "The API was unable to process every part of the request."
     },
+    500: {
+        "raise_exception": JiraInternalServerError,
+        "message": "The server encountered an unexpected condition which prevented it from fulfilling the request."
+    },
+    501: {
+        "raise_exception": JiraNotImplementedError,
+        "message": "The server does not support the functionality required to fulfill the request."
+    },
     502: {
-        "raise_exception": JiraBadGateway,
+        "raise_exception": JiraBadGatewayError,
         "message": "Server received an invalid response."
     },
     503: {
@@ -111,7 +119,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
         "message": "API service is currently unavailable."
     },
     504: {
-        "raise_exception": JiraGatewayTimeout,
+        "raise_exception": JiraGatewayTimeoutError,
         "message": "API service time out, please check Jira server."
     }
 }

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -45,7 +45,7 @@ class JiraBadGateway(JiraError):
     pass
 
 
-class JiraNotFoundError(JiraBackoffError):
+class JiraNotFoundError(JiraError):
     pass
 
 
@@ -112,8 +112,8 @@ def check_status(response):
     if response.status_code != 200:
         message = "HTTP-error-code: {}, Error: {}".format(
             response.status_code,
-            response_json.get("status", ERROR_CODE_EXCEPTION_MAPPING.get(
-                response.status_code, {})).get("message", "Unknown Error")
+            response_json.get("errorMessages", [ERROR_CODE_EXCEPTION_MAPPING.get(
+                response.status_code, {}).get("message", "Unknown Error")])[0]
         )
         exc = ERROR_CODE_EXCEPTION_MAPPING.get(
             response.status_code, {}).get("raise_exception", JiraError)

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -40,8 +40,13 @@ class JiraUnauthorizedError(JiraError):
 class JiraForbiddenError(JiraError):
     pass
 
+class JiraSubRequestFailedError(JiraError):
+    pass
 
 class JiraBadGateway(JiraError):
+    pass
+
+class JiraConflictError(JiraError):
     pass
 
 
@@ -79,15 +84,23 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     403: {
         "raise_exception": JiraForbiddenError,
-        "message": "User doesn't have permission to access the resource."
+        "message": "User does not have permission to access the resource."
     },
     404: {
         "raise_exception": JiraNotFoundError,
         "message": "The resource you have specified cannot be found."
     },
+    409: {
+        "raise_exception": JiraConflictError,
+        "message": "The request doesn't match our state in some way."
+    },
     429: {
         "raise_exception": JiraRateLimitError,
         "message": "The API rate limit for your organisation/application pairing has been exceeded."
+    },
+    449:{
+        "raise_exception": JiraSubRequestFailedError,
+        "message": "The API was unable to process every part of the request."
     },
     502: {
         "raise_exception": JiraBadGateway,

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -92,7 +92,7 @@ ERROR_CODE_EXCEPTION_MAPPING = {
     },
     409: {
         "raise_exception": JiraConflictError,
-        "message": "The request doesn't match our state in some way."
+        "message": "The request does not match our state in some way."
     },
     429: {
         "raise_exception": JiraRateLimitError,

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -2,7 +2,6 @@ from datetime import datetime, timedelta
 import time
 import threading
 import re
-from json.decoder import JSONDecodeError
 from requests.exceptions import HTTPError
 from requests.auth import HTTPBasicAuth
 import requests
@@ -108,7 +107,7 @@ def check_status(response):
     # Forming a response message for raising custom exception
     try:
         response_json = response.json()
-    except JSONDecodeError:
+    except Exception: # pylint: disable=broad-except
         response_json = {}
     if response.status_code != 200:
         message = "HTTP-error-code: {}, Error: {}".format(

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -1,6 +1,5 @@
 import json
 import pytz
-import requests
 import singer
 
 from singer import metrics, utils, metadata, Transformer

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -4,7 +4,7 @@ import requests
 import singer
 
 from singer import metrics, utils, metadata, Transformer
-from .http import Paginator
+from .http import Paginator,JiraNotFoundError
 from .context import Context
 
 
@@ -174,11 +174,8 @@ class Users(Stream):
                                         "/rest/api/2/group/member",
                                         params=params):
                     self.write_page(page)
-            except requests.exceptions.HTTPError as http_error:
-                if http_error.response.status_code == 404:
-                    LOGGER.info("Could not find group \"%s\", skipping", group)
-                else:
-                    raise http_error
+            except JiraNotFoundError:
+                LOGGER.info("Could not find group \"%s\", skipping", group)
 
 
 class Issues(Stream):

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -3,6 +3,7 @@ from unittest import mock
 import requests
 from tap_jira import http
 from tap_jira import streams
+from tap_jira.context import Context
 
 # mock responce
 class Mockresponse:
@@ -66,39 +67,200 @@ class TestJiraErrorHandling(unittest.TestCase):
     def mock_send_505(*args, **kwargs):
         return Mockresponse("",505,raise_error=True)    
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_400)
-    def test_request_with_handling_for_400_exceptin_handling(self,mock_send):
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_400)
+    # def test_request_with_handling_for_400_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraBadRequestError as e:
+    #         expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+            
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_401)
+    # def test_request_with_handling_for_401_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraUnauthorizedError as e:
+    #         expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+            
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_403)
+    # def test_request_with_handling_for_403_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraForbiddenError as e:
+    #         expected_error_message = "HTTP-error-code: 403, Error: User does not have permission to access the resource."
+
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+            
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_404)
+    # def test_request_with_handling_for_404_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraNotFoundError as e:
+    #         expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+    
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_409)
+    # def test_request_with_handling_for_409_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraConflictError as e:
+    #         expected_error_message = "HTTP-error-code: 409, Error: The request does not match our state in some way."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_429)
+    # def test_request_with_handling_for_429_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraRateLimitError as e:
+    #         expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+    #         self.assertEquals(mock_send.call_count,10)
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_449)
+    # def test_request_with_handling_for_449_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraSubRequestFailedError as e:
+    #         expected_error_message = "HTTP-error-code: 449, Error: The API was unable to process every part of the request."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+
+    
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_500)
+    # def test_request_with_handling_for_500_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraInternalServerError as e:
+    #         expected_error_message = "HTTP-error-code: 500, Error: The server encountered an unexpected condition which prevented it from fulfilling the request."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+
+    
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_501)
+    # def test_request_with_handling_for_501_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraNotImplementedError as e:
+    #         expected_error_message = "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+
+    
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_502)
+    # def test_request_with_handling_for_502_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraBadGatewayError as e:
+    #         expected_error_message = "HTTP-error-code: 502, Error: Server received an invalid response."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+            
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_503)
+    # def test_request_with_handling_for_503_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraServiceUnavailableError as e:
+    #         expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+    #         self.assertEquals(mock_send.call_count,10)
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_504)
+    # def test_request_with_handling_for_504_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraGatewayTimeoutError as e:
+    #         expected_error_message = "HTTP-error-code: 504, Error: API service time out, please check Jira server."
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+            
+
+    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_505)
+    # def test_request_with_handling_for_505_exceptin_handling(self,mock_send):
+    #     try:
+    #         tap_stream_id = "tap_jira"
+    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+    #         mock_client = http.Client(mock_config)
+    #         mock_client.request(tap_stream_id)
+    #     except http.JiraError as e:
+    #         expected_error_message = "HTTP-error-code: 505, Error: Unknown Error"
+    #         # Verifying the message formed for the custom exception
+    #         self.assertEquals(str(e), expected_error_message)
+
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_400_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_400()
+            Context.retrieve_timezone()
         except http.JiraBadRequestError as e:
             expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
             
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_401)
-    def test_request_with_handling_for_401_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_401_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_401()
+            Context.retrieve_timezone()
         except http.JiraUnauthorizedError as e:
             expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
             
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_403)
-    def test_request_with_handling_for_403_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_403_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_403()
+            Context.retrieve_timezone()
         except http.JiraForbiddenError as e:
             expected_error_message = "HTTP-error-code: 403, Error: User does not have permission to access the resource."
 
@@ -106,128 +268,106 @@ class TestJiraErrorHandling(unittest.TestCase):
             self.assertEquals(str(e), expected_error_message)
             
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_404)
-    def test_request_with_handling_for_404_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_404_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_404()
+            Context.retrieve_timezone()
         except http.JiraNotFoundError as e:
             expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
     
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_409)
-    def test_request_with_handling_for_409_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_409_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_409()
+            Context.retrieve_timezone()
         except http.JiraConflictError as e:
             expected_error_message = "HTTP-error-code: 409, Error: The request does not match our state in some way."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_429)
-    def test_request_with_handling_for_429_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_429_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_429()
+            Context.retrieve_timezone()
         except http.JiraRateLimitError as e:
             expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
-            self.assertEquals(mock_send.call_count,10)
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_449)
-    def test_request_with_handling_for_449_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_449_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_449()
+            Context.retrieve_timezone()
         except http.JiraSubRequestFailedError as e:
             expected_error_message = "HTTP-error-code: 449, Error: The API was unable to process every part of the request."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
 
     
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_500)
-    def test_request_with_handling_for_500_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_500_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_500()
+            Context.retrieve_timezone()
         except http.JiraInternalServerError as e:
             expected_error_message = "HTTP-error-code: 500, Error: The server encountered an unexpected condition which prevented it from fulfilling the request."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
 
     
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_501)
-    def test_request_with_handling_for_501_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_501_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_501()
+            Context.retrieve_timezone()
         except http.JiraNotImplementedError as e:
             expected_error_message = "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
 
     
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_502)
-    def test_request_with_handling_for_502_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_502_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_502()
+            Context.retrieve_timezone()
         except http.JiraBadGatewayError as e:
             expected_error_message = "HTTP-error-code: 502, Error: Server received an invalid response."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
             
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_503)
-    def test_request_with_handling_for_503_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_503_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_503()
+            Context.retrieve_timezone()
         except http.JiraServiceUnavailableError as e:
             expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
-            self.assertEquals(mock_send.call_count,10)
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_504)
-    def test_request_with_handling_for_504_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_504_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_504()
+            Context.retrieve_timezone()
         except http.JiraGatewayTimeoutError as e:
             expected_error_message = "HTTP-error-code: 504, Error: API service time out, please check Jira server."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
             
 
-    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_505)
-    def test_request_with_handling_for_505_exceptin_handling(self,mock_send):
+    @mock.patch("tap_jira.context.Context.client")
+    def test_retrieve_timezone_with_handling_for_505_exceptin_handling(self,mock_context_client):
         try:
-            tap_stream_id = "tap_jira"
-            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-            mock_client = http.Client(mock_config)
-            mock_client.request(tap_stream_id)
+            mock_context_client.send.return_value = self.mock_send_505()
+            Context.retrieve_timezone()
         except http.JiraError as e:
             expected_error_message = "HTTP-error-code: 505, Error: Unknown Error"
             # Verifying the message formed for the custom exception

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -103,7 +103,6 @@ class TestJiraErrorHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
-            self.assertEquals(mock_send.call_count,10)
 
     @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_429)
     def test_request_with_handling_for_429_exceptin_handling(self,mock_send):

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -48,6 +48,12 @@ class TestJiraErrorHandling(unittest.TestCase):
     def mock_send_449(*args, **kwargs):
         return Mockresponse("",449,raise_error=True)
 
+    def mock_send_500(*args, **kwargs):
+        return Mockresponse("",500,raise_error=True)
+
+    def mock_send_501(*args, **kwargs):
+        return Mockresponse("",501,raise_error=True)
+    
     def mock_send_502(*args, **kwargs):
         return Mockresponse("",502,raise_error=True)
 
@@ -149,6 +155,33 @@ class TestJiraErrorHandling(unittest.TestCase):
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
 
+    
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_500)
+    def test_request_with_handling_for_500_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraBadGateway as e:
+            expected_error_message = "HTTP-error-code: 500, Error: The server encountered an unexpected condition which prevented it from fulfilling the request."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+
+    
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_501)
+    def test_request_with_handling_for_501_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraBadGateway as e:
+            expected_error_message = "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+
+    
     @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_502)
     def test_request_with_handling_for_502_exceptin_handling(self,mock_send):
         try:

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -103,7 +103,7 @@ class TestJiraErrorHandling(unittest.TestCase):
             expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
-            
+            self.assertEquals(mock_send.call_count,10)
 
     @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_429)
     def test_request_with_handling_for_429_exceptin_handling(self,mock_send):

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -163,7 +163,7 @@ class TestJiraErrorHandling(unittest.TestCase):
             mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
             mock_client = http.Client(mock_config)
             mock_client.request(tap_stream_id)
-        except http.JiraBadGateway as e:
+        except http.JiraInternalServerError as e:
             expected_error_message = "HTTP-error-code: 500, Error: The server encountered an unexpected condition which prevented it from fulfilling the request."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
@@ -176,7 +176,7 @@ class TestJiraErrorHandling(unittest.TestCase):
             mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
             mock_client = http.Client(mock_config)
             mock_client.request(tap_stream_id)
-        except http.JiraBadGateway as e:
+        except http.JiraNotImplementedError as e:
             expected_error_message = "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
@@ -189,7 +189,7 @@ class TestJiraErrorHandling(unittest.TestCase):
             mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
             mock_client = http.Client(mock_config)
             mock_client.request(tap_stream_id)
-        except http.JiraBadGateway as e:
+        except http.JiraBadGatewayError as e:
             expected_error_message = "HTTP-error-code: 502, Error: Server received an invalid response."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
@@ -215,7 +215,7 @@ class TestJiraErrorHandling(unittest.TestCase):
             mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
             mock_client = http.Client(mock_config)
             mock_client.request(tap_stream_id)
-        except http.JiraGatewayTimeout as e:
+        except http.JiraGatewayTimeoutError as e:
             expected_error_message = "HTTP-error-code: 504, Error: API service time out, please check Jira server."
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -1,0 +1,171 @@
+import unittest
+from unittest import mock
+import requests
+from tap_jira import http
+
+# mock responce
+class Mockresponse:
+    def __init__(self, resp, status_code, content=[], headers=None, raise_error=False):
+        self.json_data = resp
+        self.status_code = status_code
+        self.content = content
+        self.headers = headers
+        self.raise_error = raise_error
+
+    def prepare(self):
+        return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+
+        raise requests.HTTPError("mock sample message")
+
+    def json(self):
+        return self.text
+
+class TestJiraErrorHandling(unittest.TestCase):
+
+    def mock_send_400(*args, **kwargs):
+        return Mockresponse("",400,raise_error=True)
+
+    def mock_send_401(*args, **kwargs):
+        return Mockresponse("",401,raise_error=True)
+
+    def mock_send_403(*args, **kwargs):
+        return Mockresponse("",403,raise_error=True)
+
+    def mock_send_404(*args, **kwargs):
+        return Mockresponse("",404,raise_error=True)
+
+    def mock_send_429(*args, **kwargs):
+        return Mockresponse("",429,raise_error=True)
+
+    def mock_send_502(*args, **kwargs):
+        return Mockresponse("",502,raise_error=True)
+
+    def mock_send_503(*args, **kwargs):
+        return Mockresponse("",503,raise_error=True)
+
+    def mock_send_504(*args, **kwargs):
+        return Mockresponse("",504,raise_error=True)
+
+    def mock_send_505(*args, **kwargs):
+        return Mockresponse("",505,raise_error=True)    
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_400)
+    def test_request_with_handling_for_400_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraBadRequestError as e:
+            expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_401)
+    def test_request_with_handling_for_401_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraUnauthorizedError as e:
+            expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_403)
+    def test_request_with_handling_for_403_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraForbiddenError as e:
+            expected_error_message = "HTTP-error-code: 403, Error: User doesn't have permission to access the resource."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_404)
+    def test_request_with_handling_for_404_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraNotFoundError as e:
+            expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_429)
+    def test_request_with_handling_for_429_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraRateLimitError as e:
+            expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_send.call_count,10)
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_502)
+    def test_request_with_handling_for_502_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraBadGateway as e:
+            expected_error_message = "HTTP-error-code: 502, Error: Server received an invalid response."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_503)
+    def test_request_with_handling_for_503_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraServiceUnavailableError as e:
+            expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_send.call_count,10)
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_504)
+    def test_request_with_handling_for_504_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraGatewayTimeout as e:
+            expected_error_message = "HTTP-error-code: 504, Error: API service time out, please check Jira server."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            
+
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_505)
+    def test_request_with_handling_for_505_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraError as e:
+            expected_error_message = "HTTP-error-code: 505, Error: Unknown Error"
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -67,172 +67,172 @@ class TestJiraErrorHandling(unittest.TestCase):
     def mock_send_505(*args, **kwargs):
         return Mockresponse("",505,raise_error=True)    
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_400)
-    # def test_request_with_handling_for_400_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraBadRequestError as e:
-    #         expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_400)
+    def test_request_with_handling_for_400_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraBadRequestError as e:
+            expected_error_message = "HTTP-error-code: 400, Error: A validation exception has occurred."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
             
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_401)
-    # def test_request_with_handling_for_401_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraUnauthorizedError as e:
-    #         expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_401)
+    def test_request_with_handling_for_401_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraUnauthorizedError as e:
+            expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
             
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_403)
-    # def test_request_with_handling_for_403_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraForbiddenError as e:
-    #         expected_error_message = "HTTP-error-code: 403, Error: User does not have permission to access the resource."
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_403)
+    def test_request_with_handling_for_403_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraForbiddenError as e:
+            expected_error_message = "HTTP-error-code: 403, Error: User does not have permission to access the resource."
 
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
             
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_404)
-    # def test_request_with_handling_for_404_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraNotFoundError as e:
-    #         expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_404)
+    def test_request_with_handling_for_404_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraNotFoundError as e:
+            expected_error_message = "HTTP-error-code: 404, Error: The resource you have specified cannot be found."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
     
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_409)
-    # def test_request_with_handling_for_409_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraConflictError as e:
-    #         expected_error_message = "HTTP-error-code: 409, Error: The request does not match our state in some way."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_409)
+    def test_request_with_handling_for_409_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraConflictError as e:
+            expected_error_message = "HTTP-error-code: 409, Error: The request does not match our state in some way."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_429)
-    # def test_request_with_handling_for_429_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraRateLimitError as e:
-    #         expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
-    #         self.assertEquals(mock_send.call_count,10)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_429)
+    def test_request_with_handling_for_429_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraRateLimitError as e:
+            expected_error_message = "HTTP-error-code: 429, Error: The API rate limit for your organisation/application pairing has been exceeded."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_send.call_count,10)
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_449)
-    # def test_request_with_handling_for_449_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraSubRequestFailedError as e:
-    #         expected_error_message = "HTTP-error-code: 449, Error: The API was unable to process every part of the request."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
-
-    
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_500)
-    # def test_request_with_handling_for_500_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraInternalServerError as e:
-    #         expected_error_message = "HTTP-error-code: 500, Error: The server encountered an unexpected condition which prevented it from fulfilling the request."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_449)
+    def test_request_with_handling_for_449_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraSubRequestFailedError as e:
+            expected_error_message = "HTTP-error-code: 449, Error: The API was unable to process every part of the request."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
 
     
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_501)
-    # def test_request_with_handling_for_501_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraNotImplementedError as e:
-    #         expected_error_message = "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_500)
+    def test_request_with_handling_for_500_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraInternalServerError as e:
+            expected_error_message = "HTTP-error-code: 500, Error: The server encountered an unexpected condition which prevented it from fulfilling the request."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
 
     
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_502)
-    # def test_request_with_handling_for_502_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraBadGatewayError as e:
-    #         expected_error_message = "HTTP-error-code: 502, Error: Server received an invalid response."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_501)
+    def test_request_with_handling_for_501_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraNotImplementedError as e:
+            expected_error_message = "HTTP-error-code: 501, Error: The server does not support the functionality required to fulfill the request."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+
+    
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_502)
+    def test_request_with_handling_for_502_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraBadGatewayError as e:
+            expected_error_message = "HTTP-error-code: 502, Error: Server received an invalid response."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
             
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_503)
-    # def test_request_with_handling_for_503_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraServiceUnavailableError as e:
-    #         expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
-    #         self.assertEquals(mock_send.call_count,10)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_503)
+    def test_request_with_handling_for_503_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraServiceUnavailableError as e:
+            expected_error_message = "HTTP-error-code: 503, Error: API service is currently unavailable."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+            self.assertEquals(mock_send.call_count,10)
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_504)
-    # def test_request_with_handling_for_504_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraGatewayTimeoutError as e:
-    #         expected_error_message = "HTTP-error-code: 504, Error: API service time out, please check Jira server."
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_504)
+    def test_request_with_handling_for_504_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraGatewayTimeoutError as e:
+            expected_error_message = "HTTP-error-code: 504, Error: API service time out, please check Jira server."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
             
 
-    # @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_505)
-    # def test_request_with_handling_for_505_exceptin_handling(self,mock_send):
-    #     try:
-    #         tap_stream_id = "tap_jira"
-    #         mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
-    #         mock_client = http.Client(mock_config)
-    #         mock_client.request(tap_stream_id)
-    #     except http.JiraError as e:
-    #         expected_error_message = "HTTP-error-code: 505, Error: Unknown Error"
-    #         # Verifying the message formed for the custom exception
-    #         self.assertEquals(str(e), expected_error_message)
+    @mock.patch("tap_jira.http.Client.send",side_effect=mock_send_505)
+    def test_request_with_handling_for_505_exceptin_handling(self,mock_send):
+        try:
+            tap_stream_id = "tap_jira"
+            mock_config = {"username":"mock_username","password":"mock_password","base_url": "mock_base_url"}
+            mock_client = http.Client(mock_config)
+            mock_client.request(tap_stream_id)
+        except http.JiraError as e:
+            expected_error_message = "HTTP-error-code: 505, Error: Unknown Error"
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
 
     @mock.patch("tap_jira.context.Context.client")
     def test_retrieve_timezone_with_handling_for_400_exceptin_handling(self,mock_context_client):


### PR DESCRIPTION
# Description of change
- Updated error handling of HTTP error and added Retry for error code 503.

# Manual QA steps
 - Check retry is working for 503.
 - Instead of an error code proper message is coming now. 
 - Other functionalities working as is.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
