### PR TITLE
TDL-7575: Prevent connection for 401 in check mode

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -59,7 +59,7 @@ class Client():
             LOGGER.info("Using Basic Auth API authentication")
             self.base_url = config.get("base_url")
             self.auth = HTTPBasicAuth(config.get("username"), config.get("password"))
-            self.test_credentials_are_authorized()
+            self.test_basic_credentials_are_authorized()
 
     def url(self, path):
         if self.is_cloud:
@@ -145,6 +145,10 @@ class Client():
         # Assume that everyone has issues, so we try and hit that endpoint
         self.request("issues", "GET", "/rest/api/2/search",
                      params={"maxResults": 1})
+
+    def test_basic_credentials_are_authorized(self):
+        # Make a call to myself endpoint for verify creds
+        self.request("test", "GET", "/rest/api/2/myself")
 
 
 class Paginator():

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -59,6 +59,7 @@ class Client():
             LOGGER.info("Using Basic Auth API authentication")
             self.base_url = config.get("base_url")
             self.auth = HTTPBasicAuth(config.get("username"), config.get("password"))
+            self.test_credentials_are_authorized()
 
     def url(self, path):
         if self.is_cloud:

--- a/tests/unittests/test_basic_auth_in_discover.py
+++ b/tests/unittests/test_basic_auth_in_discover.py
@@ -36,7 +36,7 @@ class TestBasicAuthInDiscoverMode(unittest.TestCase):
         mocked_send.return_value = get_mock_http_response(401, {})
         mocked_args.return_value = Args()
         try:
-            tap_jira.main_impl()
+            tap_jira.main()
         except HTTPError as e:
             self.assertEqual(e.response.status_code, 401)
         
@@ -49,5 +49,5 @@ class TestBasicAuthInDiscoverMode(unittest.TestCase):
         '''
         mocked_send.return_value = get_mock_http_response(200, {})
         mocked_args.return_value = Args()
-        tap_jira.main_impl()
+        tap_jira.main()
         self.assertEqual(mocked_discover.call_count, 2)

--- a/tests/unittests/test_basic_auth_in_discover.py
+++ b/tests/unittests/test_basic_auth_in_discover.py
@@ -1,0 +1,53 @@
+from unittest import mock
+
+from requests.exceptions import HTTPError
+import tap_jira
+import unittest
+import requests
+import json
+
+# Mock args
+class Args():
+    def __init__(self):
+        self.discover = True
+        self.properties = False
+        self.config = {}
+        self.state = False
+
+# Mock response
+def get_mock_http_response(status_code, content={}):
+    contents = json.dumps(content)
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers = {}
+    response._content = contents.encode()
+    return response
+
+@mock.patch('tap_jira.get_args')
+@mock.patch('tap_jira.http.Client.send')
+@mock.patch('tap_jira.discover')
+class TestBasicAuthInDiscoverMode(unittest.TestCase):
+
+    def test_basic_auth_no_access_401(self, mocked_discover, mocked_send, mocked_args):
+        '''
+            Verify exception is raised for no access(401) error code for basic auth
+            and discover is called once for setup Context.
+        '''
+        mocked_send.return_value = get_mock_http_response(401, {})
+        mocked_args.return_value = Args()
+        try:
+            tap_jira.main_impl()
+        except HTTPError as e:
+            self.assertEqual(e.response.status_code, 401)
+        
+        self.assertEqual(mocked_discover.call_count, 1)
+
+    def test_basic_auth_access_200(self, mocked_discover, mocked_send, mocked_args):
+        '''
+            Verify discover mode is called if basic auth credentials are valid
+            and dicover function is called twice for setup Context and dicover mode.
+        '''
+        mocked_send.return_value = get_mock_http_response(200, {})
+        mocked_args.return_value = Args()
+        tap_jira.main_impl()
+        self.assertEqual(mocked_discover.call_count, 2)

--- a/tests/unittests/test_basic_auth_in_discover.py
+++ b/tests/unittests/test_basic_auth_in_discover.py
@@ -37,9 +37,12 @@ class TestBasicAuthInDiscoverMode(unittest.TestCase):
         mocked_args.return_value = Args()
         try:
             tap_jira.main()
-        except HTTPError as e:
+        except tap_jira.http.JiraUnauthorizedError as e:
             self.assertEqual(e.response.status_code, 401)
-        
+            expected_error_message = "HTTP-error-code: 401, Error: Invalid authorization credentials."
+            # Verifying the message formed for the custom exception
+            self.assertEquals(str(e), expected_error_message)
+
         self.assertEqual(mocked_discover.call_count, 1)
 
     def test_basic_auth_access_200(self, mocked_discover, mocked_send, mocked_args):


### PR DESCRIPTION
# Description of change
TDL-7575: Prevent connections that would yield a 401 from becoming fully_configured
- Added one API call for checking credentials validation.

# Manual QA steps
 - Verify that tap is raising an exception for status code 401 in discover mode and prevent fully configuration.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
