### PR TITLE
move build time and notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,18 +84,18 @@ jobs:
 
 workflows:
   version: 2
-  commit:
+  commit: &commit_jobs
     jobs:
       - build:
-          context: circleci-user
+          context:
+            - circleci-user
+            - tier-1-tap-user
   build_daily:
+    <<: *commit_jobs
     triggers:
       - schedule:
-          cron: "0 6 * * *"
+          cron: "0 1 * * *"
           filters:
             branches:
               only:
                 - master
-    jobs:
-      - build:
-          context: circleci-user


### PR DESCRIPTION
# Description of change
https://jira.talendforge.org/browse/TDL-16944
Move build time to avoid conflicts with contractors and internal teams.
6:00am UTC -> 1:00 UTC (8:00pm EST, 6:30am IST)

Move slack notifications to new channel.
# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
