### PR TITLE
TDL-17701: Add missing tap-tester tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,12 @@ jobs:
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
             run-test --tap=tap-jira tests/test_pagination.py
+      - run:
+          name: 'Test All Fields'
+          command: |
+            source dev_env.sh
+            source /usr/local/share/virtualenvs/tap-tester/bin/activate
+            run-test --tap=tap-jira tests/test_all_fields.py
       - slack/notify-on-failure:
           only_for_branches: master
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -272,7 +272,7 @@ VERSIONS = Stream("versions", ["id"], indirect_stream=True)
 COMPONENTS = Stream("components", ["id"], indirect_stream=True)
 ISSUES = Issues("issues", ["id"])
 ISSUE_COMMENTS = Stream("issue_comments", ["id"], indirect_stream=True)
-ISSUE_TRANSITIONS = Stream("issue_transitions", ["id"],
+ISSUE_TRANSITIONS = Stream("issue_transitions", ["id","issueId"], # Composite primary key
                            indirect_stream=True)
 PROJECTS = Projects("projects", ["id"])
 CHANGELOGS = Stream("changelogs", ["id"], indirect_stream=True)

--- a/tests/base.py
+++ b/tests/base.py
@@ -159,7 +159,15 @@ class BaseTapTest(TapSpec, unittest.TestCase):
         string compared which works for ISO date-time strings
         """
         max_bookmarks = {}
+        # get incremental streams
+        incremental_streams = [key for key, value in self.expected_replication_method().items()
+                               if value == self.INCREMENTAL]
         for stream, batch in sync_records.items():
+            # skip stream that is not incremental
+            # as bookmark will be written for incremental streams
+            if stream not in incremental_streams:
+                continue
+
             upsert_messages = [m for m in batch.get('messages') if m['action'] == 'upsert']
             stream_record_key = self.expected_replication_key_record_paths().get(stream, set())
             stream_bookmark_key = self.expected_replication_keys().get(stream, set())
@@ -192,7 +200,14 @@ class BaseTapTest(TapSpec, unittest.TestCase):
     def min_bookmarks_by_stream(self, sync_records):
         """Return the minimum value for the replication key for each stream"""
         min_bookmarks = {}
+        # get incremental streams
+        incremental_streams = [key for key, value in self.expected_replication_method().items()
+                               if value == self.INCREMENTAL]
         for stream, batch in sync_records.items():
+            # skip stream that is not incremental
+            # as bookmark will be written for incremental streams
+            if stream not in incremental_streams:
+                continue
 
             upsert_messages = [m for m in batch.get('messages') if m['action'] == 'upsert']
             stream_record_key = self.expected_replication_key_record_paths().get(stream, set())

--- a/tests/spec.py
+++ b/tests/spec.py
@@ -97,7 +97,10 @@ class TapSpec():
                 # https://stitchdata.atlassian.net/browse/SRCE-5193
             },
             "issue_comments": id_pk, # Returned as part of the issue
-            "issue_transitions": id_pk, # Returned as part of the issue
+            "issue_transitions": {
+                    self.PRIMARY_KEYS: {"id","issueId"},# Composite primary key
+                    self.API_LIMIT: 0,
+                }, # Returned as part of the issue
             "changelogs": id_pk, # Returned as part of the issue
             "worklogs": {
                 self.PRIMARY_KEYS: {"id"},

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -8,16 +8,24 @@ from base import BaseTapTest
 class AllFieldsTest(BaseTapTest):
     """Test that with no fields selected for a stream automatic fields are still replicated"""
 
-    # fields for which data is not generated
+    # fields for which data is not generated or available via updating API Call
     fields_to_remove = {
-        "worklogs": ["properties", "visibility"],
+        # Most of the fields will be included using "expand" parameter in the API Call
+        # See backlog card: https://jira.talendforge.org/browse/TDL-17948 for more details
+        "worklogs": ["properties"],
+        # removed in the Tap
         "project_types": ["icon"],
+        # name, key: properties are deprected
+        # expand: not populated in the response
         "users": ["name", "key", "expand"],
+        # project: not populated in the response
         "versions": ["expand", "moveUnfixedIssuesTo", "project", "remotelinks", "operations"],
+        # fieldsToInclude: not found in the doc
         "issues": ["renderedFields", "schema", "editmeta", "fieldsToInclude", "versionedRepresentations", "names", "properties"],
-        "issue_comments": ["properties", "visibility", "renderedBody"],
-        "projects": ["roles", "url", "issueTypes", "email", "assigneeType", "components", "projectCategory"],
+        "issue_comments": ["properties", "renderedBody"],
+        "projects": ["roles", "issueTypes", "email", "assigneeType", "components"],
         "issue_transitions": ["fields", "expand"],
+        # iconUrl: not found in the doc
         "resolutions": ["iconUrl"],
         "changelogs": ["historyMetadata"]
     }

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -1,0 +1,85 @@
+"""
+Test that with no fields selected for a stream automatic fields are still replicated
+"""
+
+from tap_tester import runner, menagerie
+from base import BaseTapTest
+
+class AllFieldsTest(BaseTapTest):
+    """Test that with no fields selected for a stream automatic fields are still replicated"""
+
+    # fields for which data is not generated
+    fields_to_remove = {
+        "worklogs": ["properties", "visibility"],
+        "project_types": ["icon"],
+        "users": ["name", "key", "expand"],
+        "versions": ["expand", "moveUnfixedIssuesTo", "project", "remotelinks", "operations"],
+        "issues": ["renderedFields", "schema", "editmeta", "fieldsToInclude", "versionedRepresentations", "names", "properties"],
+        "issue_comments": ["properties", "visibility", "renderedBody"],
+        "projects": ["roles", "url", "issueTypes", "email", "assigneeType", "components", "projectCategory"],
+        "issue_transitions": ["fields", "expand"],
+        "resolutions": ["iconUrl"],
+        "changelogs": ["historyMetadata"]
+    }
+
+    def name(self):
+        return "tt_jira_all_fields_test"
+
+    def test_run(self):
+
+        conn_id = self.create_connection_with_initial_discovery()
+
+        self.create_test_data()
+
+        # Select all streams and no fields within streams
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.select_all_streams_and_fields(conn_id, found_catalogs, select_all_fields=True)
+
+        # grab metadata after performing table-and-field selection to set expectations
+        stream_to_all_catalog_fields = dict() # used for asserting all fields are replicated
+        for catalog in found_catalogs:
+            stream_id, stream_name = catalog['stream_id'], catalog['stream_name']
+            catalog_entry = menagerie.get_annotated_schema(conn_id, stream_id)
+            fields_from_field_level_md = [md_entry['breadcrumb'][1]
+                                          for md_entry in catalog_entry['metadata']
+                                          if md_entry['breadcrumb'] != []]
+            stream_to_all_catalog_fields[stream_name] = set(fields_from_field_level_md)
+
+        # Run a sync job using orchestrator
+        record_count_by_stream = self.run_sync(conn_id)
+        synced_records = runner.get_records_from_target_output()
+
+        # Verify no unexpected streams were replicated
+        synced_stream_names = set(synced_records.keys())
+        self.assertSetEqual(self.expected_streams(), synced_stream_names)
+
+        for stream in self.expected_streams():
+            with self.subTest(stream=stream):
+                # expected values
+                expected_automatic_keys = self.expected_primary_keys().get(stream, set()) | \
+                    self.top_level_replication_key_fields().get(stream, set()) | self.expected_foreign_keys().get(stream, set())
+                # get all expected keys
+                expected_all_keys = stream_to_all_catalog_fields[stream]
+
+                # collect actual values
+                messages = synced_records.get(stream)
+
+                actual_all_keys = set()
+                # collect actual values
+                for message in messages['messages']:
+                    if message['action'] == 'upsert':
+                        actual_all_keys.update(message['data'].keys())
+
+                # Verify that you get some records for each stream
+                self.assertGreater(record_count_by_stream.get(stream, -1), 0)
+
+                # verify all fields for a stream were replicated
+                self.assertGreater(len(expected_all_keys), len(expected_automatic_keys))
+                self.assertTrue(expected_automatic_keys.issubset(expected_all_keys), msg=f'{expected_automatic_keys-expected_all_keys} is not in "expected_all_keys"')
+
+                # remove some fields as data cannot be generated
+                fields = self.fields_to_remove.get(stream) or []
+                for field in fields:
+                    expected_all_keys.remove(field)
+
+                self.assertSetEqual(expected_all_keys, actual_all_keys)

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -42,9 +42,7 @@ class AllFieldsTest(BaseTapTest):
         # Select all streams and no fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
 
-        # BUG: https://jira.talendforge.org/browse/TDL-18287
-        #   Primary key is not unique for 'issue_transitions' stream
-        expected_streams = self.expected_streams() - {"issue_transitions"}
+        expected_streams = self.expected_streams()
         our_catalogs = [catalog for catalog in found_catalogs if
                         catalog.get('tap_stream_id') in expected_streams]
 

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -63,9 +63,7 @@ class MinimumSelectionTest(BaseTapTest):
                     msg="The fields sent to the target are not the automatic fields.\nExpected: {}\nActual: {}".format(expected_fields_for_stream, actual_fields_by_stream.get(stream, set())))
 
                 # Verify that all replicated records have unique primary key values
-                records_pks_set = {tuple([message.get('data').get(primary_key) for primary_key in expected_primary_keys])
-                                          for message in messages.get('messages')}
                 records_pks_list = [tuple([message.get('data').get(primary_key) for primary_key in expected_primary_keys])
                                            for message in messages.get('messages')]
-                self.assertCountEqual(records_pks_set, records_pks_list,
+                self.assertCountEqual(set(records_pks_list), records_pks_list,
                                       msg="We have duplicate records for {}".format(stream))

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -31,9 +31,7 @@ class MinimumSelectionTest(BaseTapTest):
         # WE WILL NEED TO UPDATE THE BELOW TO SELECT ONE
         found_catalogs = menagerie.get_catalogs(conn_id)
 
-        # BUG: https://jira.talendforge.org/browse/TDL-18287
-        #   Primary key is not unique for 'issue_transitions' stream
-        expected_streams = self.expected_streams() - {"issue_transitions"}
+        expected_streams = self.expected_streams()
         our_catalogs = [catalog for catalog in found_catalogs if
                         catalog.get('tap_stream_id') in expected_streams]
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -1,10 +1,6 @@
 """
 Test tap sets a bookmark and respects it for the next sync of a stream
 """
-from datetime import datetime as dt
-
-from dateutil.parser import parse
-
 from tap_tester import menagerie, runner
 
 from base import BaseTapTest
@@ -91,30 +87,6 @@ class BookmarkTest(BaseTapTest):
                     target_min_value = first_min_bookmarks.get(
                         stream, {None: None}).get(stream_bookmark_key)
 
-                    try:
-                        # attempt to parse the bookmark as a date
-                        if state_value:
-                            if isinstance(state_value, str):
-                                state_value = self.local_to_utc(parse(state_value))
-                            if isinstance(state_value, int):
-                                state_value = self.local_to_utc(dt.utcfromtimestamp(state_value))
-
-                        if target_value:
-                            if isinstance(target_value, str):
-                                target_value = self.local_to_utc(parse(target_value))
-                            if isinstance(target_value, int):
-                                target_value = self.local_to_utc(dt.utcfromtimestamp(target_value))
-
-                        if target_min_value:
-                            if isinstance(target_min_value, str):
-                                target_min_value = self.local_to_utc(parse(target_min_value))
-                            if isinstance(target_min_value, int):
-                                target_min_value = self.local_to_utc(
-                                    dt.utcfromtimestamp(target_min_value))
-
-                    except (OverflowError, ValueError, TypeError):
-                        print("bookmarks cannot be converted to dates, comparing values directly")
-
                     # verify that there is data with different bookmark values - setup necessary
                     self.assertGreaterEqual(target_value, target_min_value,
                                             msg="Data isn't set up to be able to test bookmarks")
@@ -132,15 +104,6 @@ class BookmarkTest(BaseTapTest):
                     # verify all data from 2nd sync >= 1st bookmark
                     target_value = second_min_bookmarks.get(
                         stream, {None: None}).get(stream_bookmark_key)
-                    try:
-                        if target_value:
-                            if isinstance(target_value, str):
-                                target_value = self.local_to_utc(parse(target_value))
-                            if isinstance(target_value, int):
-                                target_value = self.local_to_utc(dt.utcfromtimestamp(target_value))
-
-                    except (OverflowError, ValueError, TypeError):
-                        print("bookmarks cannot be converted to dates, comparing values directly")
 
                     # verify that the minimum bookmark sent to the target for the second sync
                     # is greater than or equal to the bookmark from the first sync

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -36,23 +36,24 @@ class BookmarkTest(BaseTapTest):
 
         # Select all streams and no fields within streams
         found_catalogs = menagerie.get_catalogs(conn_id)
-        incremental_streams = {key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL}
 
         # IF THERE ARE STREAMS THAT SHOULD NOT BE TESTED
         # REPLACE THE EMPTY SET BELOW WITH THOSE STREAMS
-        untested_streams = self.child_streams().union(set())
+        untested_streams = self.child_streams().union({"issue_comments", "issue_transitions", "changelogs"})
+        expected_streams = self.expected_streams().difference(untested_streams)
+
+        incremental_streams = {key for key, value in self.expected_replication_method().items()
+                               if value == self.INCREMENTAL}
+
         our_catalogs = [catalog for catalog in found_catalogs if
-                        catalog.get('tap_stream_id') in incremental_streams.difference(
-                            untested_streams)]
+                        catalog.get('tap_stream_id') in expected_streams]
         self.select_all_streams_and_fields(conn_id, our_catalogs, select_all_fields=False)
 
         # Run a sync job using orchestrator
         first_sync_record_count = self.run_sync(conn_id)
 
         # verify that the sync only sent records to the target for selected streams (catalogs)
-        self.assertEqual(set(first_sync_record_count.keys()),
-                         incremental_streams.difference(untested_streams))
+        self.assertEqual(set(first_sync_record_count.keys()), expected_streams)
 
         first_sync_state = menagerie.get_state(conn_id)
 
@@ -63,6 +64,7 @@ class BookmarkTest(BaseTapTest):
 
         # Run a second sync job using orchestrator
         second_sync_record_count = self.run_sync(conn_id)
+        second_sync_state = menagerie.get_state(conn_id)
 
         # Get data about rows synced
         second_sync_records = runner.get_records_from_target_output()
@@ -70,74 +72,92 @@ class BookmarkTest(BaseTapTest):
 
         # THIS MAKES AN ASSUMPTION THAT CHILD STREAMS DO NOT HAVE BOOKMARKS.
         # ADJUST IF NECESSARY
-        for stream in incremental_streams.difference(untested_streams):
+        for stream in expected_streams:
             with self.subTest(stream=stream):
 
-                # get bookmark values from state and target data
-                stream_bookmark_key = self.expected_replication_keys().get(stream, set())
-                print("Found bookmark key for {}: {}".format(stream, stream_bookmark_key))
-                assert len(
-                    stream_bookmark_key) == 1  # There shouldn't be a compound replication key
-                stream_bookmark_key = stream_bookmark_key.pop()
+                if stream in incremental_streams:
 
-                state_value = first_sync_state.get("bookmarks", {}).get(
-                    stream, {None: None}).get(stream_bookmark_key)
-                target_value = first_max_bookmarks.get(
-                    stream, {None: None}).get(stream_bookmark_key)
-                target_min_value = first_min_bookmarks.get(
-                    stream, {None: None}).get(stream_bookmark_key)
+                    # get bookmark values from state and target data
+                    stream_bookmark_key = self.expected_replication_keys().get(stream, set())
+                    print("Found bookmark key for {}: {}".format(stream, stream_bookmark_key))
+                    assert len(
+                        stream_bookmark_key) == 1  # There shouldn't be a compound replication key
+                    stream_bookmark_key = stream_bookmark_key.pop()
 
-                try:
-                    # attempt to parse the bookmark as a date
-                    if state_value:
-                        if isinstance(state_value, str):
-                            state_value = self.local_to_utc(parse(state_value))
-                        if isinstance(state_value, int):
-                            state_value = self.local_to_utc(dt.utcfromtimestamp(state_value))
+                    state_value = first_sync_state.get("bookmarks", {}).get(
+                        stream, {None: None}).get(stream_bookmark_key)
+                    target_value = first_max_bookmarks.get(
+                        stream, {None: None}).get(stream_bookmark_key)
+                    target_min_value = first_min_bookmarks.get(
+                        stream, {None: None}).get(stream_bookmark_key)
 
-                    if target_value:
-                        if isinstance(target_value, str):
-                            target_value = self.local_to_utc(parse(target_value))
-                        if isinstance(target_value, int):
-                            target_value = self.local_to_utc(dt.utcfromtimestamp(target_value))
+                    try:
+                        # attempt to parse the bookmark as a date
+                        if state_value:
+                            if isinstance(state_value, str):
+                                state_value = self.local_to_utc(parse(state_value))
+                            if isinstance(state_value, int):
+                                state_value = self.local_to_utc(dt.utcfromtimestamp(state_value))
 
-                    if target_min_value:
-                        if isinstance(target_min_value, str):
-                            target_min_value = self.local_to_utc(parse(target_min_value))
-                        if isinstance(target_min_value, int):
-                            target_min_value = self.local_to_utc(
-                                dt.utcfromtimestamp(target_min_value))
+                        if target_value:
+                            if isinstance(target_value, str):
+                                target_value = self.local_to_utc(parse(target_value))
+                            if isinstance(target_value, int):
+                                target_value = self.local_to_utc(dt.utcfromtimestamp(target_value))
 
-                except (OverflowError, ValueError, TypeError):
-                    print("bookmarks cannot be converted to dates, comparing values directly")
+                        if target_min_value:
+                            if isinstance(target_min_value, str):
+                                target_min_value = self.local_to_utc(parse(target_min_value))
+                            if isinstance(target_min_value, int):
+                                target_min_value = self.local_to_utc(
+                                    dt.utcfromtimestamp(target_min_value))
 
-                # verify that there is data with different bookmark values - setup necessary
-                self.assertGreaterEqual(target_value, target_min_value,
-                                        msg="Data isn't set up to be able to test bookmarks")
+                    except (OverflowError, ValueError, TypeError):
+                        print("bookmarks cannot be converted to dates, comparing values directly")
 
-                # verify state agrees with target data after 1st sync
-                self.assertEqual(state_value, target_value,
-                                 msg="The bookmark value isn't correct based on target data")
+                    # verify that there is data with different bookmark values - setup necessary
+                    self.assertGreaterEqual(target_value, target_min_value,
+                                            msg="Data isn't set up to be able to test bookmarks")
 
-                # verify that you get less data the 2nd time around
-                self.assertGreater(
-                    first_sync_record_count.get(stream, 0),
-                    second_sync_record_count.get(stream, 0),
-                    msg="second syc didn't have less records, bookmark usage not verified")
+                    # verify state agrees with target data after 1st sync
+                    self.assertEqual(state_value, target_value,
+                                    msg="The bookmark value isn't correct based on target data")
 
-                # verify all data from 2nd sync >= 1st bookmark
-                target_value = second_min_bookmarks.get(
-                    stream, {None: None}).get(stream_bookmark_key)
-                try:
-                    if target_value:
-                        if isinstance(target_value, str):
-                            target_value = self.local_to_utc(parse(target_value))
-                        if isinstance(target_value, int):
-                            target_value = self.local_to_utc(dt.utcfromtimestamp(target_value))
+                    # verify that you get less data the 2nd time around
+                    self.assertGreater(
+                        first_sync_record_count.get(stream, 0),
+                        second_sync_record_count.get(stream, 0),
+                        msg="second syc didn't have less records, bookmark usage not verified")
 
-                except (OverflowError, ValueError, TypeError):
-                    print("bookmarks cannot be converted to dates, comparing values directly")
+                    # verify all data from 2nd sync >= 1st bookmark
+                    target_value = second_min_bookmarks.get(
+                        stream, {None: None}).get(stream_bookmark_key)
+                    try:
+                        if target_value:
+                            if isinstance(target_value, str):
+                                target_value = self.local_to_utc(parse(target_value))
+                            if isinstance(target_value, int):
+                                target_value = self.local_to_utc(dt.utcfromtimestamp(target_value))
 
-                # verify that the minimum bookmark sent to the target for the second sync
-                # is greater than or equal to the bookmark from the first sync
-                self.assertGreaterEqual(target_value, state_value)
+                    except (OverflowError, ValueError, TypeError):
+                        print("bookmarks cannot be converted to dates, comparing values directly")
+
+                    # verify that the minimum bookmark sent to the target for the second sync
+                    # is greater than or equal to the bookmark from the first sync
+                    self.assertGreaterEqual(target_value, state_value)
+
+                else:
+
+                    first_bookmark_key_value = first_sync_state.get('bookmarks', {stream: None}).get(stream)
+                    second_bookmark_key_value = second_sync_state.get('bookmarks', {stream: None}).get(stream)
+                    first_sync_count = first_sync_record_count.get(stream, 0)
+                    second_sync_count = second_sync_record_count.get(stream, 0)
+
+                    # Verify the syncs do not set a bookmark for full table streams
+                    self.assertIsNone(first_bookmark_key_value)
+                    self.assertIsNone(second_bookmark_key_value)
+
+                    self.assertGreater(first_sync_count, 0)
+                    self.assertGreater(second_sync_count, 0)
+                    # Verify the number of records in the second sync is the same as the first
+                    self.assertEqual(first_sync_count, second_sync_count)

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -23,6 +23,7 @@ class DiscoveryTest(BaseTapTest):
         • Verify stream names follow naming convention
           streams should only have lowercase alphas and underscores
         • verify there is only 1 top level breadcrumb
+        • verify there are no duplicate/conflicting metadata entries
         • verify replication key(s)
         • verify primary key(s)
         • verify that if there is a replication key we are doing INCREMENTAL otherwise FULL
@@ -72,6 +73,14 @@ class DiscoveryTest(BaseTapTest):
                 stream_properties = [item for item in metadata if item.get("breadcrumb") == []]
                 self.assertTrue(len(stream_properties) == 1,
                                 msg="There is more than one top level breadcrumb")
+
+                # collect fields
+                actual_fields = []
+                for md_entry in metadata:
+                    if md_entry["breadcrumb"] != []:
+                        actual_fields.append(md_entry["breadcrumb"][1])
+                # Verify there are no duplicate/conflicting metadata entries.
+                self.assertEqual(len(actual_fields), len(set(actual_fields)), msg="There are duplicate entries in the fields of '{}' stream".format(stream))
 
                 # verify replication key(s)
                 self.assertEqual(


### PR DESCRIPTION
# Description of change
TDL-17701: Add missing tap-tester tests
- Added `test_all_fields`
- Added missing assertions in discovery, automatic fields, and bookmark test.

NOTE: The test case is failing as the Primary Key is not unique for the `issue_transition` stream. [Asked in the community](https://community.atlassian.com/t5/Jira-questions/Issue-Transition-Primary-Key/qaq-p/1933996) for the same.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
