### PR TITLE
TDL-14408 Add pk switching logic for users stream

### DIFF
--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -63,11 +63,12 @@ def discover():
 
 def generate_metadata(stream, schema):
     mdata = metadata.new()
-    mdata = metadata.write(mdata, (), 'table-key-properties', stream.pk_fields)
 
     # Update pk for users stream to key for on prem jira instance
     if stream.tap_stream_id == "users" and Context.client.is_on_prem_instance:
         stream.pk_fields = ["key"]
+
+    mdata = metadata.write(mdata, (), 'table-key-properties', stream.pk_fields)
 
     for field_name in schema.properties.keys():
         if field_name in stream.pk_fields:

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -165,6 +165,9 @@ class Client():
         self.login_timer = None
         self.timeout = get_request_timeout(config)
 
+        # Assign False for cloud Jira instance
+        self.is_on_prem_instance = False
+
         if self.is_cloud:
             LOGGER.info("Using OAuth based API authentication")
             self.auth = None
@@ -277,8 +280,9 @@ class Client():
 
     def test_basic_credentials_are_authorized(self):
         # Make a call to myself endpoint for verify creds
-        self.request("test", "GET", "/rest/api/2/myself")
-
+        # Here, we are retrieving serverInfo for the Jira instance by which credentials will also be verified.
+        # Assign True value to is_on_prem_instance property for on-prem Jira instance
+        self.is_on_prem_instance = self.request("users","GET","/rest/api/2/serverInfo").get('deploymentType') == "Server"
 
 class Paginator():
     def __init__(self, client, page_num=0, order_by=None, items_key="values"):

--- a/tests/unittests/test_basic_auth_in_discover.py
+++ b/tests/unittests/test_basic_auth_in_discover.py
@@ -31,7 +31,7 @@ class TestBasicAuthInDiscoverMode(unittest.TestCase):
     def test_basic_auth_no_access_401(self, mocked_discover, mocked_send, mocked_args):
         '''
             Verify exception is raised for no access(401) error code for basic auth
-            and discover is called once for setup Context.
+            and discover is not called.
         '''
         mocked_send.return_value = get_mock_http_response(401, {})
         mocked_args.return_value = Args()
@@ -43,7 +43,7 @@ class TestBasicAuthInDiscoverMode(unittest.TestCase):
             # Verifying the message formed for the custom exception
             self.assertEquals(str(e), expected_error_message)
 
-        self.assertEqual(mocked_discover.call_count, 1)
+        self.assertEqual(mocked_discover.call_count, 0)
 
     def test_basic_auth_access_200(self, mocked_discover, mocked_send, mocked_args):
         '''

--- a/tests/unittests/test_pk_switching.py
+++ b/tests/unittests/test_pk_switching.py
@@ -2,6 +2,7 @@ from unittest import mock
 from unittest.mock import Mock
 from tap_jira.http import Client
 from tap_jira.streams import ALL_STREAMS
+from tap_jira.context import Context
 import tap_jira
 import unittest
 import requests
@@ -59,7 +60,7 @@ class TestPkSwitchingForUserStream(unittest.TestCase):
 
         jira_client = Client(JIRA_CONFIG)
         jira_client.is_on_prem_instance = True
-
+        Context.client = jira_client
         # `users` stream
         users_stream = ALL_STREAMS[7]
 
@@ -67,7 +68,7 @@ class TestPkSwitchingForUserStream(unittest.TestCase):
         schema = Mock()
         schema.properties = {}
 
-        tap_jira.generate_metadata(users_stream, schema, jira_client)
+        tap_jira.generate_metadata(users_stream, schema)
 
         # Verify primary key of stream
         self.assertEqual(users_stream.pk_fields, ["key"])
@@ -82,6 +83,7 @@ class TestPkSwitchingForUserStream(unittest.TestCase):
 
         jira_client = Client(JIRA_CONFIG)
         jira_client.is_on_prem_instance = False
+        Context.client = jira_client
 
         # `users` stream
         users_stream = ALL_STREAMS[7]
@@ -90,7 +92,7 @@ class TestPkSwitchingForUserStream(unittest.TestCase):
         schema = Mock()
         schema.properties = {}
 
-        tap_jira.generate_metadata(users_stream, schema, jira_client)
+        tap_jira.generate_metadata(users_stream, schema)
 
         # Verify primary key of stream
         self.assertEqual(users_stream.pk_fields, ["accountId"])
@@ -111,7 +113,7 @@ class TestPkSwitchingForUserStream(unittest.TestCase):
         schema = Mock()
         schema.properties = {}
 
-        tap_jira.generate_metadata(users_stream, schema, jira_client)
+        tap_jira.generate_metadata(users_stream, schema)
 
         # Verify primary key of stream
         self.assertEqual(users_stream.pk_fields, ["id"])

--- a/tests/unittests/test_pk_switching.py
+++ b/tests/unittests/test_pk_switching.py
@@ -1,0 +1,117 @@
+from unittest import mock
+from unittest.mock import Mock
+from tap_jira.http import Client
+from tap_jira.streams import ALL_STREAMS
+import tap_jira
+import unittest
+import requests
+import json
+
+# Mock args
+JIRA_CONFIG = {
+  "start_date": "2020-02-10",
+  "username": "dummy_admin",
+  "password": "dummy@000",
+  "base_url": "http://127.0.0.1:8000",
+}
+
+# Mock response
+def get_mock_http_response(status_code, content={}):
+    contents = json.dumps(content)
+    response = requests.Response()
+    response.status_code = status_code
+    response.headers = {}
+    response._content = contents.encode()
+    return response
+
+@mock.patch('tap_jira.http.Client.send')
+class TestPkSwitchingForUserStream(unittest.TestCase):
+
+    def test_pk_for_cloud_jira(self, mocked_send):
+        '''
+            Verify is_on_prem_instance property of Client remain False when `deploymentType`
+            is `Cloud` in the response
+        '''
+        mocked_send.return_value = get_mock_http_response(200, {"deploymentType": "Cloud"})
+
+        jira_client = Client(JIRA_CONFIG)
+
+        self.assertEqual(jira_client.is_on_prem_instance, False)
+
+    def test_pk_for_on_prem_jira(self, mocked_send):
+        '''
+            Verify is_on_prem_instance property of Client changed True when `deploymentType`
+            is `Server` in the response
+        '''
+        mocked_send.return_value = get_mock_http_response(200, {"deploymentType": "Server"})
+
+        jira_client = Client(JIRA_CONFIG)
+
+        self.assertEqual(jira_client.is_on_prem_instance, True)
+
+    @mock.patch('singer.metadata')
+    def test_pk_update_for_on_prem_jira(self, mocked_metadata, mocked_send):
+        '''
+            Verify primary key of users stream is updated to `key` when is_on_prem_instance property
+            of Client is True(on prem jira account)
+        '''
+        mocked_send.return_value = get_mock_http_response(200, {})
+
+        jira_client = Client(JIRA_CONFIG)
+        jira_client.is_on_prem_instance = True
+
+        # `users` stream
+        users_stream = ALL_STREAMS[7]
+
+        # mock schema and it's properties
+        schema = Mock()
+        schema.properties = {}
+
+        tap_jira.generate_metadata(users_stream, schema, jira_client)
+
+        # Verify primary key of stream
+        self.assertEqual(users_stream.pk_fields, ["key"])
+
+    @mock.patch('singer.metadata')
+    def test_pk_update_for_cloud_jira(self, mocked_metadata, mocked_send):
+        '''
+            Verify primary key of users stream is `accountId` when is_on_prem_instance property
+            of Client is False(cloud jira account)
+        '''
+        mocked_send.return_value = get_mock_http_response(200, {})
+
+        jira_client = Client(JIRA_CONFIG)
+        jira_client.is_on_prem_instance = False
+
+        # `users` stream
+        users_stream = ALL_STREAMS[7]
+
+        # mock schema and it's properties
+        schema = Mock()
+        schema.properties = {}
+
+        tap_jira.generate_metadata(users_stream, schema, jira_client)
+
+        # Verify primary key of stream
+        self.assertEqual(users_stream.pk_fields, ["accountId"])
+
+    @mock.patch('singer.metadata')
+    def test_pk_update_for_non_users_stream(self, mocked_metadata, mocked_send):
+        '''
+            Verify primary key of all other streams remain unchanged.
+        '''
+        mocked_send.return_value = get_mock_http_response(200, {})
+
+        jira_client = Client(JIRA_CONFIG)
+
+        # `resolutions` stream(other than users stream)
+        users_stream = ALL_STREAMS[5]
+
+        # mock schema and it's properties
+        schema = Mock()
+        schema.properties = {}
+
+        tap_jira.generate_metadata(users_stream, schema, jira_client)
+
+        # Verify primary key of stream
+        self.assertEqual(users_stream.pk_fields, ["id"])


### PR DESCRIPTION
# Description of change
**TDL-14408 Investigate how to handle pk switching for on-prem vs cloud Jira**
- In the discover mode, we are checking the Jira instance type by making an API call.
- If an on-prem Jira instance is found, then we are updating the primary key of users as key
- For the cloud Jira instance, the primary key remains unchanged.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
