### PR TITLE
Optionally Refresh OAuth Credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ This tap:
      "cloud_id": "<cloud-id>",
      "refresh_token": "<refresh-token>",
      "start_date": "<i.e. 2017-12-04T19:19:32Z>",
-     "request_timeout": 300
+     "request_timeout": 300,
+     "refresh_credentials": "true"
    }
    ```
 
@@ -66,6 +67,9 @@ This tap:
    For Basic Auth, the `base_url` is the URL where your Jira installation
    can be found. For example, it might look like:
    `https://mycompany.atlassian.net`.
+
+   The `refresh_credentials` specifies if OAuth credentials i.e (access token and refersh token) 
+   needs to be refreshed. By default, `refresh_credentials` value is set to `true`.
 
 4. Run the Tap in Discovery Mode
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -178,13 +178,18 @@ class Client():
             # Only appears to be needed once for any 6 hour period. If
             # running the tap for more than 6 hours is needed this will
             # likely need to be more complicated.
-            self.refresh_credentials()
+            if self._check_refresh_credentials(config):
+                self.refresh_credentials()
             self.test_credentials_are_authorized()
         else:
             LOGGER.info("Using Basic Auth API authentication")
             self.base_url = config.get("base_url")
             self.auth = HTTPBasicAuth(config.get("username"), config.get("password"))
             self.test_basic_credentials_are_authorized()
+
+    def _check_refresh_credentials(self, config):
+        if config.get("refresh_credentials") is None or str(config.get("refresh_credentials")).lower() == "true": 
+            return True
 
     def url(self, path):
         if self.is_cloud:


### PR DESCRIPTION
# Description of change
This PR mainly focuses on Optionally refreshing OAuth credentials. Introduced a `refresh_credentials` key to config.json to specify if OAuth credentials need to be refreshed. By default, `refresh_credentials` is set to `true` for backward-compatibility.
Link to tap-Jira issue: https://github.com/singer-io/tap-jira/issues/77

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
