### PR TITLE
Added support for personal access token i.e. jira onprem

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ This tap:
    }
    ```
 
+  or (for Personal Access Token):
+
+  ```json
+  {
+      "start_date": "2010-01-01",
+      "access_token": "<personal-access-token>",
+      "base_url": "https://your-jira-domain",
+      "user_agent": "<user-agent>",
+      "request_timeout": 300
+  }
+
    The `start_date` specifies the date at which the tap will begin pulling data
    (for those resources that support this).
 

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -17,19 +17,25 @@ REQUIRED_CONFIG_KEYS_CLOUD = ["start_date",
                               "refresh_token",
                               "oauth_client_id",
                               "oauth_client_secret"]
+
 REQUIRED_CONFIG_KEYS_HOSTED = ["start_date",
-                               "username",
-                               "password",
                                "base_url",
                                "user_agent"]
+
+REQUIRED_CONFIG_KEYS_HOSTED_PAT = ["access_token"]
+
+REQUIRED_CONFIG_KEYS_HOSTED_BASIC_AUTH = ["username",
+                                          "password"]
 
 
 def get_args():
     unchecked_args = utils.parse_args([])
-    if 'username' in unchecked_args.config.keys():
-        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED)
-
-    return utils.parse_args(REQUIRED_CONFIG_KEYS_CLOUD)
+    if 'oauth_client_id' in unchecked_args.config.keys():
+        return utils.parse_args(REQUIRED_CONFIG_KEYS_CLOUD)
+    if "base_url" in unchecked_args.config.keys() and "access_token" in unchecked_args.config.keys():
+        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED + REQUIRED_CONFIG_KEYS_HOSTED_PAT)
+        
+    return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED + REQUIRED_CONFIG_KEYS_HOSTED_BASIC_AUTH)
 
 
 def get_abs_path(path):


### PR DESCRIPTION
# Description of change
This PR mainly focuses on adding support for personal access token to Jira on-prem. there is some minor change in logic for `get_args` function. Link to tap-Jira issue: https://github.com/singer-io/tap-jira/issues/79
For detailed information please refer: https://confluence.atlassian.com/enterprise/using-personal-access-tokens-1026032365.html

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
