### PR TITLE
Bump version for Jira

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [v2.1.2]
+  * Added Missing Test Cases [#74](https://github.com/singer-io/tap-jira/pull/74)
+  * Updated Project stream with new endpoint as old one is deprecated [#75](https://github.com/singer-io/tap-jira/pull/75)
+  * Primary Key Switching change for On prem JIRA [#76](https://github.com/singer-io/tap-jira/pull/76)
+  * Updating primary key for issue_transition_stream [#81](https://github.com/singer-io/tap-jira/pull/81)
 ## [v2.1.1]
   * Request Timeout Implementation [#71](https://github.com/singer-io/tap-jira/pull/71)
 ## [v2.1.0]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-jira",
-      version="2.1.1",
+      version="2.1.2",
       description="Singer.io tap for extracting data from the Jira API",
       author="Stitch",
       url="http://singer.io",


### PR DESCRIPTION
# Description of change
* Added Missing Test Cases (https://github.com/singer-io/tap-jira/pull/74)
* Updated Project stream with new endpoint as old one is deprecated (https://github.com/singer-io/tap-jira/pull/75)
  * Primary Key Switching change for On prem JIRA (https://github.com/singer-io/tap-jira/pull/76)
  * Updating primary key for issue_transition_stream(https://github.com/singer-io/tap-jira/pull/81)

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
