### PR TITLE
Consider catalog file when populating a schema message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v2.1.3]
+  * Fixed Tranform Issues [#84](https://github.com/singer-io/tap-jira/pull/84)
 ## [v2.1.2]
   * Added Missing Test Cases [#74](https://github.com/singer-io/tap-jira/pull/74)
   * Updated Project stream with new endpoint as old one is deprecated [#75](https://github.com/singer-io/tap-jira/pull/75)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-jira",
-      version="2.1.2",
+      version="2.1.3",
       description="Singer.io tap for extracting data from the Jira API",
       author="Stitch",
       url="http://singer.io",


### PR DESCRIPTION
# Description of change
In the current implementation, the catalog.json being passed is not considered for the creation of the schema message.
The schema always matches the schema in the schema json files within the repository.
This leads to the following issues:
* Fields that are not selected will still stay in the schema
* Fields provided by the catalog file are not present in the schema at all

We encountered this issue when we synced to a BigQuery target. The table created did not match the data in the records.



# Manual QA steps
 - Run the tap in sync mode without providing a catalog.json file -> it should use the default schema and populate this in the schema message
 - Run the tap in sync mode with a catalog.json file where you set certain fields to `"selected": false` -> those fields should not show up in the schema message
 - Run the tap in sync mode with a catalog.json file that contains fields that are not part of the default schema (e.g. custom jira fields) -> those fields should show up in the schema message
 
# Risks
 - Existing implementations might show different behavior in case they provided a catalog.json file where certain fields are unselected
 
# Rollback steps
 - revert this branch
