### PR TITLE
Tdl 19582 replication records inclusive of start date

### DIFF
--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -6,7 +6,9 @@ from datetime import datetime as dt
 from datetime import timedelta
 
 from tap_tester import menagerie, runner
-from tap_tester.logger import LOGGER
+# from tap_tester.logger import LOGGER
+import singer
+LOGGER = singer.get_logger()
 
 from base import BaseTapTest
 
@@ -49,7 +51,7 @@ class StartDateTest(BaseTapTest):
     def test_run(self):
         """Test we get a lot of data back based on the start date configured in base"""
 
-        streams_under_test = self.streams_under_test()
+        streams_under_test = {"worklogs"} # self.streams_under_test()
 
         conn_id = self.create_connection_with_initial_discovery()
 
@@ -75,8 +77,7 @@ class StartDateTest(BaseTapTest):
 
         # grab the most recent bookmark from state
         greatest_bookmark_value = sorted(bookmarked_values)[-1].split("T")[0]
-        start_date = self.timedelta_formatted(greatest_bookmark_value, days=-1, str_format="%Y-%m-%d") # BUG_TDL-19582
-        # start_date = self.timedelta_formatted(greatest_bookmark_value, days=0, str_format="%Y-%m-%d")  # BUG_TDL-19582
+        start_date = self.timedelta_formatted(greatest_bookmark_value, days=0, str_format="%Y-%m-%d")
         self.start_date = start_date + "T00:00:00Z"
 
         # create a new connection with the new  more recent start_date

--- a/tests/test_start_date.py
+++ b/tests/test_start_date.py
@@ -6,13 +6,10 @@ from datetime import datetime as dt
 from datetime import timedelta
 
 from tap_tester import menagerie, runner
-# from tap_tester.logger import LOGGER
-import singer
-LOGGER = singer.get_logger()
+from tap_tester.logger import LOGGER
 
 from base import BaseTapTest
 
-# BUG_TDL-19582 [tap-jira] tap does not replicate incremental records inclusive of start date
 
 
 class StartDateTest(BaseTapTest):
@@ -51,7 +48,7 @@ class StartDateTest(BaseTapTest):
     def test_run(self):
         """Test we get a lot of data back based on the start date configured in base"""
 
-        streams_under_test = {"worklogs"} # self.streams_under_test()
+        streams_under_test = self.streams_under_test()
 
         conn_id = self.create_connection_with_initial_discovery()
 
@@ -75,9 +72,9 @@ class StartDateTest(BaseTapTest):
             replication_key = list(expected_replication_keys_by_stream[stream])[0]
             bookmarked_values.append(state['bookmarks'][stream][replication_key])
 
-        # grab the most recent bookmark from state
-        greatest_bookmark_value = sorted(bookmarked_values)[-1].split("T")[0]
-        start_date = self.timedelta_formatted(greatest_bookmark_value, days=0, str_format="%Y-%m-%d")
+        # Grab the minimum bookmark from the state to fetch data from all the streams in sync2
+        minium_bookmark_value = sorted(bookmarked_values)[0].split("T")[0]
+        start_date = self.timedelta_formatted(minium_bookmark_value, days=0, str_format="%Y-%m-%d")
         self.start_date = start_date + "T00:00:00Z"
 
         # create a new connection with the new  more recent start_date


### PR DESCRIPTION
# Description of change
- Tap is already replication records inclusive of the start date for worklogs stream.
- In the start_date test case, a maximum of all bookmarks were being used as the start date for 2nd sync.
  - Here, the maximum bookmark was `2022-02-24` and the last record of `worklogs` was for `2022-02-23`. That's why in the 2nd sync we were not getting any records of `worklogs`.
- Updated `start_date` test case to get records of all streams.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
