### PR TITLE
bump version 2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [v2.1.5]
+  * Skipped the record for out of range date values [#87](https://github.com/singer-io/tap-jira/pull/87)
 ## [v2.1.4]
   * Updated README [#88](https://github.com/singer-io/tap-jira/pull/88)
 ## [v2.1.3]

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-jira",
-      version="2.1.4",
+      version="2.1.5",
       description="Singer.io tap for extracting data from the Jira API",
       author="Stitch",
       url="http://singer.io",


### PR DESCRIPTION
# Description of change

Skipped record for out of range date : [#87](https://github.com/singer-io/tap-jira/pull/87)
