### PR TITLE
Properties

### DIFF
--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -59,3 +59,11 @@ class Context():
         response = cls.client.send("GET", "/rest/api/2/myself")
         check_status(response)
         return response.json()["timeZone"]
+
+    @classmethod
+    def is_property_selected(cls, stream_name, property_name):
+        stream = cls.get_catalog_entry(stream_name)
+        properties_selected = [x["breadcrumb"][1] for x in stream.metadata \
+            if len(x["breadcrumb"]) == 2 and x["breadcrumb"][0] == "properties" \
+            and x["metadata"].get("selected", False) == True]
+        return property_name in properties_selected

--- a/tap_jira/schemas/issues.json
+++ b/tap_jira/schemas/issues.json
@@ -45,21 +45,8 @@
         "null",
         "object"
       ],
-      "properties": {
-        "properties": {
-          "type": [
-            "null",
-            "object"
-          ],
-          "patternProperties": {
-            ".+": {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          }
-        }
+      "patternProperties": {
+        ".+": {}
       }
     },
     "names": {


### PR DESCRIPTION
# Description of change

Add support for fetching issue's properties. The current REST entrypoint used does not include properties, so another fetch to the server is required. The extra fetch is conditional, it checks if the property Properties in the schema is selected. 

# Manual QA steps

Inspecting the records to be synced into a target shows the properties as JSON objects correctly
 
# Risks
 
The approach is the same as the fields property, but I don't know the internal process on how a new column/table is generated on the target side.
 
# Rollback steps

Revert this branch
