### PR TITLE
update expected results based on new api responses

### DIFF
--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -28,7 +28,8 @@ class AllFieldsTest(BaseTapTest):
         "issue_transitions": ["fields", "expand"],
         # iconUrl: not found in the doc
         "resolutions": ["iconUrl"],
-        "changelogs": ["historyMetadata"]
+        # historyMetadata started showing up 01/24/2023 so commenting this out for now
+        # "changelogs": ["historyMetadata"]
     }
 
     @staticmethod


### PR DESCRIPTION
# Description of change
Previously the test removed historyMetadata from the expected results as we were unable to generate data for this field but it started coming back from the API recently so the expectation was updated to allow the test to pass again.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
