### PR TITLE
Work around paginator flaw by querying issues in descending order

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -230,6 +230,7 @@ class Client():
                                        auth=self.auth,
                                        headers=self._headers(headers),
                                        **kwargs)
+        LOGGER.info("Sending API request to %s with params %s", request.url, kwargs)
         return self.session.send(request.prepare(), timeout=self.timeout)
 
     @backoff.on_exception(backoff.constant,


### PR DESCRIPTION
# Description of change
Resolves #109 by querying issue data in descending update order.

# Manual QA steps
- I added more logging to manually demonstrate that a record can be skipped if another record is updated on a page that has been previously queried.  After this change, we can get duplicates in this situation, which may be removed by downstream singer targets.
 
# Risks
 - Dupes may not always be treated gracefully in targets.
 
# Rollback steps
 - revert this branch
