### PR TITLE
Remove expand field from users stream

### DIFF
--- a/tap_jira/schemas/users.json
+++ b/tap_jira/schemas/users.json
@@ -74,12 +74,6 @@
         "null",
         "string"
       ]
-    },
-    "expand": {
-      "type": [
-        "null",
-        "string"
-      ]
     }
   }
 }


### PR DESCRIPTION
# Description of change
Remove `expand` field from `users` stream since it is not returned by the `group/member` endpoint.

Please refer PR #41  for more details.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
