### PR TITLE
feat: add replication-method discoverable metadata to streams

### DIFF
--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -69,6 +69,7 @@ def generate_metadata(stream, schema):
         stream.pk_fields = ["key"]
 
     mdata = metadata.write(mdata, (), 'table-key-properties', stream.pk_fields)
+    mdata = metadata.write(mdata, (), 'forced-replication-method', stream.replication_method)
 
     for field_name in schema.properties.keys():
         if field_name in stream.pk_fields:

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -69,7 +69,9 @@ def generate_metadata(stream, schema):
         stream.pk_fields = ["key"]
 
     mdata = metadata.write(mdata, (), 'table-key-properties', stream.pk_fields)
-    mdata = metadata.write(mdata, (), 'forced-replication-method', stream.replication_method)
+    mdata = metadata.write(mdata, (), 'forced-replication-method', stream.forced_replication_method)
+    if stream.parent_tap_stream_id is not None:
+        mdata = metadata.write(mdata, (), 'parent-tap-stream-id', stream.parent_tap_stream_id)
 
     for field_name in schema.properties.keys():
         if field_name in stream.pk_fields:


### PR DESCRIPTION
-----------------------------

# Description of change
[SAC-27991](https://qlik-dev.atlassian.net/browse/SAC-27991) seeks to add forced-replication-method and parent-tap-stream-id to all of it's streams.

# Manual QA steps
 - Ran tap-tester
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
