### PR TITLE
SAC-28633: Add metric tags

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -244,7 +244,7 @@ class Client():
             response = self.send(*args, **kwargs)
             self.next_request_at = datetime.now() + TIME_BETWEEN_REQUESTS
             timer.tags[metrics.Tag.http_status_code] = response.status_code
-            timer.tags["http_method"] = args[0]
+            timer.tags["http_method"] = response.request.method
             timer.tags["tap_stream_id"] = tap_stream_id
             timer.tags["endpoint"] = response.url
         check_status(response)

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -244,6 +244,9 @@ class Client():
             response = self.send(*args, **kwargs)
             self.next_request_at = datetime.now() + TIME_BETWEEN_REQUESTS
             timer.tags[metrics.Tag.http_status_code] = response.status_code
+            timer.tags["http_method"] = args[0]
+            timer.tags["tap_stream_id"] = tap_stream_id
+            timer.tags["endpoint"] = response.url
         check_status(response)
         return response.json()
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -165,6 +165,7 @@ class Stream():
 
         with metrics.record_counter(self.tap_stream_id) as counter:
             counter.increment(rec_count) # Do not increment counter for skipped records
+            counter.tags["tap_stream_id"] = self.tap_stream_id
 
 def update_user_date(page):
     """

--- a/tests/unittests/test_basic_auth_in_discover.py
+++ b/tests/unittests/test_basic_auth_in_discover.py
@@ -21,6 +21,9 @@ def get_mock_http_response(status_code, content={}):
     response.status_code = status_code
     response.headers = {}
     response._content = contents.encode()
+    response.url = ""
+    response.request = requests.Request()
+    response.request.method = ""
     return response
 
 @mock.patch('tap_jira.get_args')

--- a/tests/unittests/test_error_handling.py
+++ b/tests/unittests/test_error_handling.py
@@ -13,6 +13,9 @@ class Mockresponse:
         self.content = content
         self.headers = headers
         self.raise_error = raise_error
+        self.url = ""
+        self.request = mock.Mock()
+        self.request.method = ""
 
     def prepare(self):
         return (self.json_data, self.status_code, self.content, self.headers, self.raise_error)

--- a/tests/unittests/test_pk_switching.py
+++ b/tests/unittests/test_pk_switching.py
@@ -23,6 +23,9 @@ def get_mock_http_response(status_code, content={}):
     response.status_code = status_code
     response.headers = {}
     response._content = contents.encode()
+    response.url = ""
+    response.request = requests.Request()
+    response.request.method = ""
     return response
 
 @mock.patch('tap_jira.http.Client.send')

--- a/tests/unittests/test_projects_stream.py
+++ b/tests/unittests/test_projects_stream.py
@@ -27,6 +27,9 @@ def get_mock_http_response(status_code, content={}):
     response.status_code = status_code
     response.headers = {}
     response._content = contents.encode()
+    response.url = ""
+    response.request = requests.Request()
+    response.request.method = ""
     return response
 
 first_page = get_projects_response(is_last=False)

--- a/tests/unittests/test_request_timeout.py
+++ b/tests/unittests/test_request_timeout.py
@@ -9,6 +9,9 @@ def get_mock_http_response(*args, **kwargs):
     response = requests.Response()
     response.status_code = 200
     response._content = contents.encode()
+    response.url = ""
+    response.request = requests.Request()
+    response.request.method = ""
     return response
 
 


### PR DESCRIPTION
# Description of change
This PR adds more tags to the `singer-python.metrics.http_request_timer` and `singer-python.metrics.record_counter` objects.

# Manual QA steps
 - Ran the tap
 
# Risks
 - Low. This should not affect any of the functionality in the day-to-day use of the tap, despite what the unit tests would have to think.
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
- [X] 100% Human made code