### PR TITLE
Sac 29184/add bookmarks to issues child streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
+## [v2.7.0]
+  * Copies the Issues parent stream's bookmark to its child streams [#132](https://github.com/singer-io/tap-jira/pull/132)
 ## [v2.6.0]
   * Fallback mechanism for JIRA API requests to support on-premises instances [#131](https://github.com/singer-io/tap-jira/pull/131)
-
 ## [v2.5.0]
   * Add extra tags to `http_request_timer` metrics and `record_counter` metrics [#129](https://github.com/singer-io/tap-jira/pull/129)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-jira",
-      version="2.6.0",
+      version="2.7.0",
       description="Singer.io tap for extracting data from the Jira API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -90,21 +90,22 @@ def output_schema(stream):
 def sync():
     streams_.validate_dependencies()
 
+    # If the Issues' bookmark has been reset, check to clear the child stream bookmarks so they remain synchronized.
+    # Update bookmark before first state message is emitted
+    if "issues" not in Context.bookmarks():
+        children_streams = ["issue_comments", "changelogs", "issue_transitions"]
+        for child in children_streams:
+            cleared_bookmark = Context.clear_bookmark(child)
+            cleared_target_state = Context.clear_target_state(child)
+            if cleared_bookmark or cleared_target_state:
+                LOGGER.info(f"Parent stream 'issues' bookmark is empty. Clearing state for child stream: {child}")
 
     # two loops through streams are necessary so that the schema is output
     # BEFORE syncing any streams. Otherwise, the first stream might generate
     # data for the second stream, but the second stream hasn't output its
     # schema yet
+    
     for stream in streams_.ALL_STREAMS:
-        # If the Issues' bookmark has been reset, check to clear the child stream bookmarks so they remain synchronized.
-        # Update bookmark before first state message is emitted
-        if stream.tap_stream_id == "issues" and "issues" not in Context.bookmarks():
-            children_streams = ["issue_comments", "changelogs", "issue_transitions"]
-            for child in children_streams:
-                cleared = Context.clear_bookmark(child)
-                if cleared:
-                    LOGGER.info(f"Parent stream 'issues' bookmark is empty. Clearing state for child stream: {child}")
-
         output_schema(stream)
 
     for stream in streams_.ALL_STREAMS:

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -108,7 +108,7 @@ def sync():
             continue
         Context.state["currently_syncing"] = stream.tap_stream_id
 
-        # If the Issues' bookmark has been reset, check to clear the child stream bookmarks so they remain synchronized. 
+        # If the Issues' bookmark has been reset, check to clear the child stream bookmarks so they remain synchronized.
         if stream.tap_stream_id == "issues" and "issues" not in Context.bookmarks():
             children_streams = ["issue_comments", "changelogs", "issue_transitions"]
             for child in children_streams:
@@ -116,9 +116,9 @@ def sync():
                 if cleared:
                     LOGGER.info(f"Parent stream 'issues' bookmark is empty. Clearing state for child stream: {child}")
         singer.write_state(Context.state)
-        
+
         stream.sync()
-        
+
     Context.state["currently_syncing"] = None
     singer.write_state(Context.state)
 

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -90,11 +90,11 @@ def output_schema(stream):
 def sync():
     streams_.validate_dependencies()
 
+    
     # two loops through streams are necessary so that the schema is output
     # BEFORE syncing any streams. Otherwise, the first stream might generate
     # data for the second stream, but the second stream hasn't output its
-    # schema yet
-    
+    # schema yet    
     for stream in streams_.ALL_STREAMS:
         output_schema(stream)
 
@@ -108,9 +108,7 @@ def sync():
             continue
         Context.state["currently_syncing"] = stream.tap_stream_id
         singer.write_state(Context.state)
-
         stream.sync()
-
     Context.state["currently_syncing"] = None
     singer.write_state(Context.state)
 

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -107,8 +107,17 @@ def sync():
         if stream.indirect_stream:
             continue
         Context.state["currently_syncing"] = stream.tap_stream_id
+
+        # If the Issues' bookmark has been reset, check to clear the child stream bookmarks so they remain synchronized. 
+        if stream.tap_stream_id == "issues" and "issues" not in Context.bookmarks():
+            children_streams = ["issue_comments", "changelogs", "issue_transitions"]
+            for stream in children_streams:
+                cleared = Context.clear_bookmark(stream)
+                if cleared:
+                    LOGGER.info(f"Parent stream 'issues' bookmark is empty. Clearing state for child stream: {stream}")
         singer.write_state(Context.state)
         stream.sync()
+        
     Context.state["currently_syncing"] = None
     singer.write_state(Context.state)
 

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -111,11 +111,12 @@ def sync():
         # If the Issues' bookmark has been reset, check to clear the child stream bookmarks so they remain synchronized. 
         if stream.tap_stream_id == "issues" and "issues" not in Context.bookmarks():
             children_streams = ["issue_comments", "changelogs", "issue_transitions"]
-            for stream in children_streams:
-                cleared = Context.clear_bookmark(stream)
+            for child in children_streams:
+                cleared = Context.clear_bookmark(child)
                 if cleared:
-                    LOGGER.info(f"Parent stream 'issues' bookmark is empty. Clearing state for child stream: {stream}")
+                    LOGGER.info(f"Parent stream 'issues' bookmark is empty. Clearing state for child stream: {child}")
         singer.write_state(Context.state)
+        
         stream.sync()
         
     Context.state["currently_syncing"] = None

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -90,16 +90,6 @@ def output_schema(stream):
 def sync():
     streams_.validate_dependencies()
 
-    # If the Issues' bookmark has been reset, check to clear the child stream bookmarks so they remain synchronized.
-    # Update bookmark before first state message is emitted
-    if "issues" not in Context.bookmarks():
-        children_streams = ["issue_comments", "changelogs", "issue_transitions"]
-        for child in children_streams:
-            cleared_bookmark = Context.clear_bookmark(child)
-            cleared_target_state = Context.clear_target_state(child)
-            if cleared_bookmark or cleared_target_state:
-                LOGGER.info(f"Parent stream 'issues' bookmark is empty. Clearing state for child stream: {child}")
-
     # two loops through streams are necessary so that the schema is output
     # BEFORE syncing any streams. Otherwise, the first stream might generate
     # data for the second stream, but the second stream hasn't output its

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -90,11 +90,11 @@ def output_schema(stream):
 def sync():
     streams_.validate_dependencies()
 
-    
+
     # two loops through streams are necessary so that the schema is output
     # BEFORE syncing any streams. Otherwise, the first stream might generate
     # data for the second stream, but the second stream hasn't output its
-    # schema yet    
+    # schema yet
     for stream in streams_.ALL_STREAMS:
         output_schema(stream)
 

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -90,7 +90,6 @@ def output_schema(stream):
 def sync():
     streams_.validate_dependencies()
 
-
     # two loops through streams are necessary so that the schema is output
     # BEFORE syncing any streams. Otherwise, the first stream might generate
     # data for the second stream, but the second stream hasn't output its

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -44,6 +44,12 @@ class Context():
         cls.bookmark(path[:-1])[path[-1]] = val
 
     @classmethod
+    def clear_bookmark(cls, stream):
+        if "bookmarks" not in cls.state:
+            return None
+        return cls.state["bookmarks"].pop(stream, None)
+    
+    @classmethod
     def update_start_date_bookmark(cls, path):
         val = cls.bookmark(path)
         if not val:

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -50,6 +50,12 @@ class Context():
         return cls.state["bookmarks"].pop(stream, None)
 
     @classmethod
+    def clear_target_state(cls, stream):
+        if "target_state" not in cls.state:
+            return None
+        return cls.state["target_state"].pop(stream, None)
+
+    @classmethod
     def update_start_date_bookmark(cls, path):
         val = cls.bookmark(path)
         if not val:

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -44,18 +44,6 @@ class Context():
         cls.bookmark(path[:-1])[path[-1]] = val
 
     @classmethod
-    def clear_bookmark(cls, stream):
-        if "bookmarks" not in cls.state:
-            return None
-        return cls.state["bookmarks"].pop(stream, None)
-
-    @classmethod
-    def clear_target_state(cls, stream):
-        if "target_state" not in cls.state:
-            return None
-        return cls.state["target_state"].pop(stream, None)
-
-    @classmethod
     def update_start_date_bookmark(cls, path):
         val = cls.bookmark(path)
         if not val:

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -48,7 +48,7 @@ class Context():
         if "bookmarks" not in cls.state:
             return None
         return cls.state["bookmarks"].pop(stream, None)
-    
+
     @classmethod
     def update_start_date_bookmark(cls, path):
         val = cls.bookmark(path)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -379,8 +379,8 @@ class Issues(Stream):
             last_updated = utils.strptime_to_utc(page[-1]["fields"]["updated"])
             self.write_page(page)
             Context.set_bookmark(page_num_offset, pager.next_page_num)
-            # copy parent's bookmark to children
-            self.set_bookmarks_for_issue_sub_streams(page_num_offset, pager.next_page_num)
+            # Copy parent's bookmark to children
+            self.set_bookmarks_for_issue_sub_streams(page_num_offset.copy(), pager.next_page_num)
             singer.write_state(Context.state)
         Context.set_bookmark(page_num_offset, None)
         Context.set_bookmark(updated_bookmark, last_updated)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -306,8 +306,8 @@ class Issues(Stream):
         '''ISSUE_COMMENTS, CHANGELOGS, and ISSUE_TRANSITIONS are all
         incremental child streams of the incremental stream ISSUES. The
         ISSUES' bookmark is used to query the data for both parent and
-        child streams. We add child bookmarks here because their presence
-        is required downstream to correctly calculate target_state.
+        child streams. Every incremental stream is required to have a
+        bookmark.
         These child stream bookmarks are not used during the sync.
         '''
         if Context.is_selected(ISSUE_COMMENTS.tap_stream_id):

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -300,6 +300,7 @@ class Users(Stream):
             except JiraNotFoundError:
                 LOGGER.info("Could not find group \"%s\", skipping", group)
 
+
 class Issues(Stream):
     def set_bookmarks_for_issue_sub_streams(self, bookmark_path, bookmark_value):
         '''ISSUE_COMMENTS, CHANGELOGS, and ISSUE_TRANSITIONS are all

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -304,25 +304,24 @@ class Issues(Stream):
     def set_bookmarks_for_issue_sub_streams(self, bookmark_path, bookmark_value):
         '''ISSUE_COMMENTS, CHANGELOGS, and ISSUE_TRANSITIONS are all
         incremental child streams of the incremental stream ISSUES. The
-        ISSUES' bookmark is used to query the data to load for both parent
-        and child streams. We add child bookmarks here because their
-        presence is required downstream to correctly calculate
-        target_state.
+        ISSUES' bookmark is used to query the data for both parent and
+        child streams. We add child bookmarks here because their presence
+        is required downstream to correctly calculate target_state.
         These child stream bookmarks are not used during the sync.
         '''
         if Context.is_selected(ISSUE_COMMENTS.tap_stream_id):
             bookmark_path[0] = ISSUE_COMMENTS.tap_stream_id
             Context.set_bookmark(bookmark_path, bookmark_value)
-            
+
         if Context.is_selected(CHANGELOGS.tap_stream_id):
             bookmark_path[0] = CHANGELOGS.tap_stream_id
             Context.set_bookmark(bookmark_path, bookmark_value)
-            
+
         if Context.is_selected(ISSUE_TRANSITIONS.tap_stream_id):
             bookmark_path[0] = ISSUE_TRANSITIONS.tap_stream_id
             Context.set_bookmark(bookmark_path, bookmark_value)
 
-        
+
     def sync(self):
         updated_bookmark = [self.tap_stream_id, "updated"]
         page_num_offset = [self.tap_stream_id, "offset", "page_num"]

--- a/tests/base.py
+++ b/tests/base.py
@@ -76,7 +76,7 @@ class BaseTapTest(BaseCase):
     @staticmethod
     def forced_incremental_streams():
         # "key" refers to the path in state and "path" refers to the path in the record
-        return {"issues": {"bookmark_path": "updated", "record_path": ("fields", "updated")}, "worklogs": "updated"}
+        return {"issues": {"bookmark_path": "updated", "record_path": ("fields", "updated")}, "worklogs": "updated", "issue_comments": {"bookmark_path": "updated", "record_path": ("fields", "updated")}, "issue_transitions": {"bookmark_path": "updated", "record_path": ("fields", "updated")}, "changelogs": {"bookmark_path": "updated", "record_path": ("fields", "updated")}}
 
     def expected_metadata(self):
         """The expected streams and metadata about the streams"""
@@ -305,9 +305,10 @@ class BaseTapTest(BaseCase):
         string compared which works for ISO date-time strings
         """
         max_bookmarks = {}
+        issues_child_streams = ["issue_comments", "changelogs", "issue_transitions"]
         # get incremental streams
         incremental_streams = [key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL]
+                               if value == self.INCREMENTAL and key not in issues_child_streams]
         for stream, batch in sync_records.items():
             # skip stream that is not incremental
             # as bookmark will be written for incremental streams
@@ -329,7 +330,6 @@ class BaseTapTest(BaseCase):
                     return get_bookmark(message_data[stream_record_key[0]],
                                         stream_record_key[1:])
                 return message_data[stream_record_key]
-
             bk_values = [get_bookmark(message['data'], stream_record_key) for message in upsert_messages]
             max_bookmarks[stream] = {stream_bookmark_key: None}
             for bk_value in bk_values:
@@ -346,9 +346,10 @@ class BaseTapTest(BaseCase):
     def min_bookmarks_by_stream(self, sync_records):
         """Return the minimum value for the replication key for each stream"""
         min_bookmarks = {}
+        issues_child_streams = ["issue_comments", "changelogs", "issue_transitions"]
         # get incremental streams
         incremental_streams = [key for key, value in self.expected_replication_method().items()
-                               if value == self.INCREMENTAL]
+                               if value == self.INCREMENTAL and key not in issues_child_streams]
         for stream, batch in sync_records.items():
             # skip stream that is not incremental
             # as bookmark will be written for incremental streams

--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -72,12 +72,16 @@ class AllFieldsTest(BaseTapTest):
             expected_streams, synced_stream_names,
             logging=f"verify no unexpected streams are replicated: {expected_streams}"
         )
-
+        issues_child_streams = ["issue_comments", "changelogs", "issue_transitions"]
         for stream in expected_streams:
             with self.subTest(stream=stream):
                 # expected values
-                expected_automatic_keys = self.expected_primary_keys().get(stream, set()) | \
-                    self.top_level_replication_key_fields().get(stream, set()) | self.expected_foreign_keys().get(stream, set())
+                if stream in issues_child_streams:
+                    expected_automatic_keys = self.expected_primary_keys().get(stream, set()) | \
+                        self.expected_foreign_keys().get(stream, set())
+                else:
+                    expected_automatic_keys = self.expected_primary_keys().get(stream, set()) | \
+                        self.top_level_replication_key_fields().get(stream, set()) | self.expected_foreign_keys().get(stream, set())
                 # get all expected keys
                 expected_all_keys = stream_to_all_catalog_fields[stream]
 

--- a/tests/test_automatic_fields.py
+++ b/tests/test_automatic_fields.py
@@ -43,15 +43,18 @@ class MinimumSelectionTest(BaseTapTest):
 
         actual_fields_by_stream = runner.examine_target_output_for_fields()
         synced_records = runner.get_records_from_target_output()
-
+        issues_child_streams = ["issue_comments", "changelogs", "issue_transitions"]
         for stream in expected_streams:
             with self.subTest(stream=stream):
-
                 # gather expectations
                 expected_primary_keys = self.expected_primary_keys().get(stream, set())
-                expected_automatic_fields = (expected_primary_keys |
-                                             self.top_level_replication_key_fields().get(stream, set()) |
-                                             self.expected_foreign_keys().get(stream, set()))
+                if stream in issues_child_streams:
+                    expected_automatic_fields = (expected_primary_keys |
+                                                 self.expected_foreign_keys().get(stream, set()))
+                else:
+                    expected_automatic_fields = (expected_primary_keys |
+                                                 self.top_level_replication_key_fields().get(stream, set()) |
+                                                 self.expected_foreign_keys().get(stream, set()))
                 api_limit = self.expected_metadata().get(stream, {}).get(self.API_LIMIT)
 
                 # collect results

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -69,7 +69,7 @@ class BookmarkTest(BaseTapTest):
             # Assert Issue child streams copy parent stream bookmark
             self.assertEquals(first_sync_state['bookmarks']['issues'], first_sync_state['bookmarks'][child])
             self.assertEquals(second_sync_state['bookmarks']['issues'], second_sync_state['bookmarks'][child])
-            
+
         for stream in expected_streams:
             with self.subTest(stream=stream):
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -65,6 +65,11 @@ class BookmarkTest(BaseTapTest):
         second_min_bookmarks = self.min_bookmarks_by_stream(second_sync_records)
 
         issues_child_streams = ["issue_comments", "changelogs", "issue_transitions"]
+        for child in issues_child_streams:
+            # Assert Issue child streams copy parent stream bookmark
+            self.assertEquals(first_sync_state['bookmarks']['issues'], first_sync_state['bookmarks'][child])
+            self.assertEquals(second_sync_state['bookmarks']['issues'], second_sync_state['bookmarks'][child])
+            
         for stream in expected_streams:
             with self.subTest(stream=stream):
 

--- a/tests/test_bookmarks.py
+++ b/tests/test_bookmarks.py
@@ -67,8 +67,8 @@ class BookmarkTest(BaseTapTest):
         issues_child_streams = ["issue_comments", "changelogs", "issue_transitions"]
         for child in issues_child_streams:
             # Assert Issue child streams copy parent stream bookmark
-            self.assertEquals(first_sync_state['bookmarks']['issues'], first_sync_state['bookmarks'][child])
-            self.assertEquals(second_sync_state['bookmarks']['issues'], second_sync_state['bookmarks'][child])
+            self.assertEqual(first_sync_state['bookmarks']['issues'], first_sync_state['bookmarks'][child])
+            self.assertEqual(second_sync_state['bookmarks']['issues'], second_sync_state['bookmarks'][child])
 
         for stream in expected_streams:
             with self.subTest(stream=stream):

--- a/tests/unittests/test_streams.py
+++ b/tests/unittests/test_streams.py
@@ -13,6 +13,7 @@ class TestLocalizedRequests(unittest.TestCase):
         Context.retrieve_timezone = Mock(return_value=self.tzname)
         Context.bookmark = Mock()
         Context.set_bookmark = Mock()
+        Context.is_selected = Mock()
         IssuesPaginator.pages = Mock(return_value=[])
         Context.client = Mock()
 


### PR DESCRIPTION
# Description of change
`issue_comments`, `changelogs`, and `issue_transitions` are all incremental child streams of the incremental stream `issues`. This pr copies the `issues` bookmark to each child stream selected. Because the child streams do not make queries themselves, the bookmark is ignored by the tap but will be used downstream.

# Manual QA steps
 - ran the tap locally
 
# Risks
 - low
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
