### PR TITLE
Auth On Discovery

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -285,6 +285,7 @@ class Client():
         # Make a call to myself endpoint for verify creds
         # Here, we are retrieving serverInfo for the Jira instance by which credentials will also be verified.
         # Assign True value to is_on_prem_instance property for on-prem Jira instance
+        self.is_on_prem_instance = self.request("test","GET","/rest/api/2/myself")
         self.is_on_prem_instance = self.request("users","GET","/rest/api/2/serverInfo").get('deploymentType') == "Server"
 
 class Paginator():

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -285,7 +285,7 @@ class Client():
         # Make a call to myself endpoint for verify creds
         # Here, we are retrieving serverInfo for the Jira instance by which credentials will also be verified.
         # Assign True value to is_on_prem_instance property for on-prem Jira instance
-        self.is_on_prem_instance = self.request("test","GET","/rest/api/2/myself")
+        self.request("test","GET","/rest/api/2/myself")
         self.is_on_prem_instance = self.request("users","GET","/rest/api/2/serverInfo").get('deploymentType') == "Server"
 
 class Paginator():

--- a/tests/unittests/test_projects_stream.py
+++ b/tests/unittests/test_projects_stream.py
@@ -53,6 +53,7 @@ class TestProjectsPagination(unittest.TestCase):
         projects.sync()
 
         self.assertEqual([
+            mock.call('test', 'GET', '/rest/api/2/myself'), # call for basic auth
             mock.call('users', 'GET', '/rest/api/2/serverInfo'), # call for getting server info
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 0}), # page 1 call
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 50}) # page 2 call

--- a/tests/unittests/test_projects_stream.py
+++ b/tests/unittests/test_projects_stream.py
@@ -40,7 +40,7 @@ on_prem_resp = {"deploymentType": "Server"}
 
 class TestProjectsPagination(unittest.TestCase):
 
-    @mock.patch("tap_jira.http.Client.request", side_effect = [cloud_resp,first_page, last_page])
+    @mock.patch("tap_jira.http.Client.request", side_effect = [cloud_resp,cloud_resp,first_page, last_page])
     @mock.patch('tap_jira.context.Context.get_catalog_entry')
     def test_projects_stream_pagination(self, mock_catalog_entry, mock_request):
         '''Verify that the pagination works correctly with correct page size and breaks when breaking condition occurs'''
@@ -51,17 +51,17 @@ class TestProjectsPagination(unittest.TestCase):
         Context.catalog = [mock_stream] # setting the context catalog
         projects = streams.Projects('projects', ['id'], "INCREMENTAL")
         projects.sync()
-
+        print(mock_request.mock_calls)
         self.assertEqual([
             mock.call('test', 'GET', '/rest/api/2/myself'), # call for basic auth
             mock.call('users', 'GET', '/rest/api/2/serverInfo'), # call for getting server info
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 0}), # page 1 call
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 50}) # page 2 call
             ], mock_request.mock_calls)
-        print(mock_request.mock_calls)
+
 
 class TestProjectsEndpointForSync(unittest.TestCase):
-    @mock.patch("tap_jira.http.Client.request", side_effect = [cloud_resp, last_page])
+    @mock.patch("tap_jira.http.Client.request", side_effect = [cloud_resp,cloud_resp, last_page])
     @mock.patch('tap_jira.context.Context.get_catalog_entry')
     def test_projects_sync_cloud(self, mock_catalog_entry, mock_request):
         '''Verify that project/search endpoint is called for cloud server'''
@@ -79,7 +79,7 @@ class TestProjectsEndpointForSync(unittest.TestCase):
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 0}), # verify it calls project/search endpoint
             mock_request.mock_calls[1])
 
-    @mock.patch("tap_jira.http.Client.request", side_effect = [on_prem_resp, on_prem_page])
+    @mock.patch("tap_jira.http.Client.request", side_effect = [on_prem_resp,on_prem_resp, on_prem_page])
     @mock.patch('tap_jira.context.Context.get_catalog_entry')
     def test_projects_sync_on_prem(self, mock_catalog_entry, mock_request):
         '''Verify that the project endpoint is called for on_prem server'''

--- a/tests/unittests/test_projects_stream.py
+++ b/tests/unittests/test_projects_stream.py
@@ -58,6 +58,7 @@ class TestProjectsPagination(unittest.TestCase):
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 0}), # page 1 call
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 50}) # page 2 call
             ], mock_request.mock_calls)
+        print(mock_request.mock_calls)
 
 class TestProjectsEndpointForSync(unittest.TestCase):
     @mock.patch("tap_jira.http.Client.request", side_effect = [cloud_resp, last_page])

--- a/tests/unittests/test_projects_stream.py
+++ b/tests/unittests/test_projects_stream.py
@@ -51,7 +51,7 @@ class TestProjectsPagination(unittest.TestCase):
         Context.catalog = [mock_stream] # setting the context catalog
         projects = streams.Projects('projects', ['id'], "INCREMENTAL")
         projects.sync()
-        print(mock_request.mock_calls)
+
         self.assertEqual([
             mock.call('test', 'GET', '/rest/api/2/myself'), # call for basic auth
             mock.call('users', 'GET', '/rest/api/2/serverInfo'), # call for getting server info
@@ -77,7 +77,7 @@ class TestProjectsEndpointForSync(unittest.TestCase):
 
         self.assertEqual(
             mock.call('projects', 'GET', '/rest/api/2/project/search', params={'expand': 'description,lead,url,projectKeys', 'maxResults': 50, 'startAt': 0}), # verify it calls project/search endpoint
-            mock_request.mock_calls[1])
+            mock_request.mock_calls[2])
 
     @mock.patch("tap_jira.http.Client.request", side_effect = [on_prem_resp,on_prem_resp, on_prem_page])
     @mock.patch('tap_jira.context.Context.get_catalog_entry')
@@ -94,4 +94,4 @@ class TestProjectsEndpointForSync(unittest.TestCase):
 
         self.assertEqual(
             mock.call('projects', 'GET', '/rest/api/2/project', params={'expand': 'description,lead,url,projectKeys'}), # verify it calls the project endpoint
-            mock_request.mock_calls[1])
+            mock_request.mock_calls[2])


### PR DESCRIPTION
# Description of change
Creating connections and discovery succeeds without authorizing because --url 'http://{baseurl}/rest/api/2/myself' was removed in a previous PR when adding other functionality.

# Manual QA steps
 - Try to create a connection with correct creds
 - Try to create a connection with wrong creds
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
