### PR TITLE
Pin PyJWT <2.12.1 to fix Jira ingest failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name="tap-jira",
       py_modules=["tap_jira"],
       install_requires=[
           "singer-python==5.4.1",
+          "atlassian-jwt==3.0.0",
           "requests==2.20.0",
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name="tap-jira",
       install_requires=[
           "singer-python==5.12.1",
           "atlassian-jwt==3.0.0",
+          "PyJWT>=2.2.0,<2.12.1",
           "requests==2.20.0",
           "psutil>=5.9.0",
           'minware_singer_utils@git+https://{}github.com/minwareco/minware-singer-utils.git@{}'.format(

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name="tap-jira",
       classifiers=["Programming Language :: Python :: 3 :: Only"],
       py_modules=["tap_jira"],
       install_requires=[
-          "singer-python==5.4.1",
+          "singer-python==5.12.1",
           "atlassian-jwt==3.0.0",
           "requests==2.20.0",
           'minware_singer_utils@git+https://{}github.com/minwareco/minware-singer-utils.git@{}'.format(

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(name="tap-jira",
           "singer-python==5.12.1",
           "atlassian-jwt==3.0.0",
           "requests==2.20.0",
+          "psutil>=5.9.0",
           'minware_singer_utils@git+https://{}github.com/minwareco/minware-singer-utils.git@{}'.format(
               "{}@".format(os.environ.get("GITHUB_TOKEN")) if os.environ.get("GITHUB_TOKEN") else "",
               UTILS_VERSION

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
+import os
+
+UTILS_VERSION = "f97b932a0623b60e0de7212033107848340387ef"
 
 setup(name="tap-jira",
       version="2.0.1",
@@ -12,6 +15,10 @@ setup(name="tap-jira",
           "singer-python==5.4.1",
           "atlassian-jwt==3.0.0",
           "requests==2.20.0",
+          'minware_singer_utils@git+https://{}github.com/minwareco/minware-singer-utils.git@{}'.format(
+              "{}@".format(os.environ.get("GITHUB_TOKEN")) if os.environ.get("GITHUB_TOKEN") else "",
+              UTILS_VERSION
+          )
       ],
       extras_require={
           'dev': [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 import os
 
-UTILS_VERSION = "f97b932a0623b60e0de7212033107848340387ef"
+UTILS_VERSION = os.environ.get("UTILS_VERSION")
 
 setup(name="tap-jira",
       version="2.0.1",

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -97,6 +97,11 @@ def sync():
     for stream in streams_.ALL_STREAMS:
         output_schema(stream)
 
+    # Fetch the list of all projects to enable exclude and per-project state
+    projectInitFetchStream = streams_.Projects("projects", ["id"])
+    projects = projectInitFetchStream.sync(True)
+    Context.set_available_projects(projects)
+
     for stream in streams_.ALL_STREAMS:
         if not Context.is_selected(stream.tap_stream_id):
             continue

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -17,17 +17,24 @@ REQUIRED_CONFIG_KEYS_CLOUD = ["start_date",
                               "refresh_token",
                               "oauth_client_id",
                               "oauth_client_secret"]
-REQUIRED_CONFIG_KEYS_HOSTED = ["start_date",
-                               "username",
-                               "password",
-                               "base_url",
-                               "user_agent"]
+REQUIRED_CONFIG_KEYS_HOSTED_PAT = ["start_date",
+                                   "username",
+                                   "password",
+                                   "base_url",
+                                   "user_agent"]
+REQUIRED_CONFIG_KEYS_HOSTED_JWT = ["start_date",
+                                   "jwt_client_key",
+                                   "jwt_shared_secret",
+                                   "base_url",
+                                   "user_agent"]
 
 
 def get_args():
     unchecked_args = utils.parse_args([])
     if 'username' in unchecked_args.config.keys():
-        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED)
+        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED_PAT)
+    elif 'jwt_client_key' in unchecked_args.config.keys():
+        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED_JWT)
 
     return utils.parse_args(REQUIRED_CONFIG_KEYS_CLOUD)
 

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -9,7 +9,6 @@ from . import streams as streams_
 from .context import Context
 from .http import Client
 from minware_singer_utils import SecureLogger
-import requests
 
 LOGGER = SecureLogger(singer.get_logger())
 
@@ -158,20 +157,6 @@ def main_impl():
 def main():
     try:
         main_impl()
-    except requests.exceptions.HTTPError as http_err:
-        # Check if this is the specific 400 error for Jira search API
-        if http_err.response.status_code == 400 and '/rest/api/2/search' in http_err.response.url:
-            LOGGER.error("Encountered a 400 Bad Request error with Jira search API")
-            LOGGER.error(f"URL: {http_err.response.url}")
-            LOGGER.error(f"Response body: {http_err.response.text}")
-            # Continue execution without raising the exception
-        else:
-            # For other HTTP errors, log and re-raise
-            LOGGER.error(f"HTTP Error occurred: {http_err}")
-            LOGGER.error(f"URL: {http_err.response.url}")
-            LOGGER.error(f"Status code: {http_err.response.status_code}")
-            LOGGER.error(f"Response body: {http_err.response.text}")
-            raise http_err
     except Exception as exc:
         LOGGER.critical(exc)
         raise exc

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -9,6 +9,7 @@ from . import streams as streams_
 from .context import Context
 from .http import Client
 from minware_singer_utils import SecureLogger
+import requests
 
 LOGGER = SecureLogger(singer.get_logger())
 
@@ -157,6 +158,20 @@ def main_impl():
 def main():
     try:
         main_impl()
+    except requests.exceptions.HTTPError as http_err:
+        # Check if this is the specific 400 error for Jira search API
+        if http_err.response.status_code == 400 and '/rest/api/2/search' in http_err.response.url:
+            LOGGER.error("Encountered a 400 Bad Request error with Jira search API")
+            LOGGER.error(f"URL: {http_err.response.url}")
+            LOGGER.error(f"Response body: {http_err.response.text}")
+            # Continue execution without raising the exception
+        else:
+            # For other HTTP errors, log and re-raise
+            LOGGER.error(f"HTTP Error occurred: {http_err}")
+            LOGGER.error(f"URL: {http_err.response.url}")
+            LOGGER.error(f"Status code: {http_err.response.status_code}")
+            LOGGER.error(f"Response body: {http_err.response.text}")
+            raise http_err
     except Exception as exc:
         LOGGER.critical(exc)
         raise exc

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -8,8 +8,10 @@ from singer.catalog import Catalog, CatalogEntry, Schema
 from . import streams as streams_
 from .context import Context
 from .http import Client
+from minware_singer_utils import SecureLogger
 
-LOGGER = singer.get_logger()
+LOGGER = SecureLogger(singer.get_logger())
+
 REQUIRED_CONFIG_KEYS_CLOUD = ["start_date",
                               "user_agent",
                               "cloud_id",
@@ -28,6 +30,18 @@ REQUIRED_CONFIG_KEYS_HOSTED_JWT = ["start_date",
                                    "base_url",
                                    "user_agent"]
 
+def mask_secrets(config, logger):
+    SECRETS = [ "access_token",
+                "refresh_token",
+                "oauth_client_id",
+                "oauth_client_secret",
+                "username",
+                "password", 
+                "jwt_client_key",
+                "jwt_shared_secret"]
+    for secret in SECRETS:
+        if secret in config:
+            logger.addToken(config[secret])
 
 def get_args():
     unchecked_args = utils.parse_args([])
@@ -119,7 +133,8 @@ def sync():
 
 def main_impl():
     args = get_args()
-
+    mask_secrets(args.config, LOGGER)
+    
     # Setup Context
     catalog = Catalog.from_dict(args.properties) \
         if args.properties else discover()
@@ -127,7 +142,7 @@ def main_impl():
     Context.state = args.state
     Context.catalog = catalog
 
-    Context.client = Client(Context.config)
+    Context.client = Client(Context.config, LOGGER)
 
     try:
         if args.discover:

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -13,14 +13,11 @@ class Context():
     def get_projects(cls):
         projectsRaw = cls.config.get("projects", None)
         if projectsRaw:
-            # force back to a list
-            return list(
-                # filter out empty strings
-                filter(lambda p: len(p) > 0,
-                    # convert comma-separated list into array
-                    map(lambda p: p.strip(), projectsRaw.split(","))
-                )
-            )
+            # convert comma-separated list into array
+            projectsList = list(map(lambda p: p.strip(), projectsRaw.split(",")))
+            # filter out empty strings
+            projectsList = list(filter(lambda p: len(p) > 0, projectsList))
+            return projectsList
         return []
 
     @classmethod

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -10,6 +10,11 @@ class Context():
     stream_map = {}
 
     @classmethod
+    def get_projects(cls):
+        projectsRaw = cls.config.get("projects", "")
+        return list(map(lambda p: p.strip(), projectsRaw.split(",")))
+
+    @classmethod
     def get_catalog_entry(cls, stream_name):
         if not cls.stream_map:
             cls.stream_map = {s.tap_stream_id: s for s in cls.catalog.streams}

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -25,7 +25,6 @@ class Context():
     def get_catalog_entry(cls, stream_name):
         if not cls.stream_map:
             cls.stream_map = {s.tap_stream_id: s for s in cls.catalog.streams}
-            singer.get_logger().info('{}'.format(cls.stream_map))
         return cls.stream_map.get(stream_name)
 
     @classmethod

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from singer import utils, metadata
+import singer
 
 
 class Context():
@@ -24,11 +25,14 @@ class Context():
     def get_catalog_entry(cls, stream_name):
         if not cls.stream_map:
             cls.stream_map = {s.tap_stream_id: s for s in cls.catalog.streams}
-        return cls.stream_map[stream_name]
+            singer.get_logger().info('{}'.format(cls.stream_map))
+        return cls.stream_map.get(stream_name)
 
     @classmethod
     def is_selected(cls, stream_name):
         stream = cls.get_catalog_entry(stream_name)
+        if stream is None:
+            return False
         stream_metadata = metadata.to_map(stream.metadata)
         return metadata.get(stream_metadata, (), 'selected')
 

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -11,8 +11,17 @@ class Context():
 
     @classmethod
     def get_projects(cls):
-        projectsRaw = cls.config.get("projects", "")
-        return list(map(lambda p: p.strip(), projectsRaw.split(",")))
+        projectsRaw = cls.config.get("projects", None)
+        if projectsRaw:
+            # force back to a list
+            return list(
+                # filter out empty strings
+                filter(lambda p: len(p) > 0,
+                    # convert comma-separated list into array
+                    map(lambda p: p.strip(), projectsRaw.split(","))
+                )
+            )
+        return []
 
     @classmethod
     def get_catalog_entry(cls, stream_name):

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -9,17 +9,33 @@ class Context():
     catalog = None
     client = None
     stream_map = {}
+    allProjectsList = []
 
     @classmethod
     def get_projects(cls):
         projectsRaw = cls.config.get("projects", None)
+        excludeProjects = cls.config.get("exclude_projects", None)
         if projectsRaw:
             # convert comma-separated list into array
             projectsList = list(map(lambda p: p.strip(), projectsRaw.split(",")))
             # filter out empty strings
             projectsList = list(filter(lambda p: len(p) > 0, projectsList))
             return projectsList
-        return []
+        elif excludeProjects:
+            # convert comma-separated list into array
+            excludeProjectsList = list(map(lambda p: p.strip(), excludeProjects.split(",")))
+            # filter out empty strings
+            excludeProjectsList = list(filter(lambda p: len(p) > 0, excludeProjectsList))
+            return list(set(cls.allProjectsList) - set(excludeProjectsList))
+        else:
+            return cls.allProjectsList
+
+    @classmethod
+    def set_available_projects(cls, projectList):
+        projectKeys = []
+        for project in projectList:
+            projectKeys.append(project["key"])
+        cls.allProjectsList = projectKeys
 
     @classmethod
     def get_catalog_entry(cls, stream_name):

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -54,7 +54,11 @@ class Context():
     def set_bookmark(cls, path, val):
         if isinstance(val, datetime):
             val = utils.strftime(val)
-        cls.bookmark(path[:-1])[path[-1]] = val
+
+        if val is None:
+            cls.bookmark(path[:-1]).pop(path[-1], None)
+        else:
+            cls.bookmark(path[:-1])[path[-1]] = val
 
     @classmethod
     def update_start_date_bookmark(cls, path):

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -92,3 +92,7 @@ class Context():
         response = cls.client.send("GET", "/rest/api/2/myself")
         response.raise_for_status()
         return response.json()["timeZone"]
+
+    @classmethod
+    def get_exclude_issue_fields(cls):
+        return [str(x) for x in cls.config.get("exclude_issue_fields", [])]

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from singer import utils, metadata
-import singer
 
 
 class Context():

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -88,9 +88,12 @@ class Context():
 
     @classmethod
     def retrieve_timezone(cls):
-        response = cls.client.send("GET", "/rest/api/2/myself")
-        response.raise_for_status()
-        return response.json()["timeZone"]
+        # Cache the timezone to avoid repeated API calls
+        if not hasattr(cls, 'timezone_cache'):
+            # Use client.request instead of client.send to respect backoff logic
+            response_json = cls.client.request("timezone", "GET", "/rest/api/2/myself")
+            cls.timezone_cache = response_json["timeZone"]
+        return cls.timezone_cache
 
     @classmethod
     def get_exclude_issue_fields(cls):

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from singer import utils, metadata
-
+from functools import cache
 
 class Context():
     config = None
@@ -87,13 +87,10 @@ class Context():
         return val
 
     @classmethod
+    @cache
     def retrieve_timezone(cls):
-        # Cache the timezone to avoid repeated API calls
-        if not hasattr(cls, 'timezone_cache'):
-            # Use client.request instead of client.send to respect backoff logic
-            response_json = cls.client.request("timezone", "GET", "/rest/api/2/myself")
-            cls.timezone_cache = response_json["timeZone"]
-        return cls.timezone_cache
+        response_json = cls.client.request("timezone", "GET", "/rest/api/2/myself")
+        return response_json["timeZone"]
 
     @classmethod
     def get_exclude_issue_fields(cls):

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -142,6 +142,8 @@ class Client():
             timer.tags[metrics.Tag.http_status_code] = response.status_code
         if response.status_code == 429:
             raise RateLimitException()
+        elif response.status_code >= 400:
+            LOGGER.warn('Response text: {}'.format(response.status_code, response.text))
         response.raise_for_status()
         return response.json()
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -142,8 +142,8 @@ class Client():
             timer.tags[metrics.Tag.http_status_code] = response.status_code
         if response.status_code == 429:
             raise RateLimitException()
-        elif response.status_code >= 400:
-            LOGGER.warn('Response text: {}'.format(response.status_code, response.text))
+        elif response.text and response.status_code >= 400:
+            LOGGER.warn('Response body: {}'.format(response.text))
         response.raise_for_status()
         return response.json()
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -5,6 +5,7 @@ import re
 from requests.exceptions import HTTPError
 from requests.auth import HTTPBasicAuth
 import requests
+import atlassian_jwt
 from singer import metrics
 import singer
 import backoff
@@ -35,10 +36,12 @@ def should_retry_httperror(exception):
 class Client():
     def __init__(self, config):
         self.is_cloud = 'oauth_client_id' in config.keys()
+        self.jwt_config = config.get('jwt')
         self.session = requests.Session()
         self.next_request_at = datetime.now()
         self.user_agent = config.get("user_agent")
         self.login_timer = None
+        self.jwt_config = None
 
         if self.is_cloud:
             LOGGER.info("Using OAuth based API authentication")
@@ -55,6 +58,10 @@ class Client():
             # likely need to be more complicated.
             self.refresh_credentials()
             self.test_credentials_are_authorized()
+        elif self.jwt_config is not None:
+            LOGGER.info("Using JWT API authentication")
+            self.base_url = config.get("base_url")
+            self.auth = None
         else:
             LOGGER.info("Using Basic Auth API authentication")
             self.base_url = config.get("base_url")
@@ -70,7 +77,7 @@ class Client():
         base_url = 'https://' + base_url
         return base_url.rstrip("/") + "/" + path.lstrip("/")
 
-    def _headers(self, headers):
+    def _headers(self, headers, method, path):
         headers = headers.copy()
         if self.user_agent:
             headers["User-Agent"] = self.user_agent
@@ -79,8 +86,21 @@ class Client():
             # Add OAuth Headers
             headers['Accept'] = 'application/json'
             headers['Authorization'] = 'Bearer {}'.format(self.access_token)
+        elif self.jwt_config is not None:
+            # Add JWT headers
+            jwtToken = self._generateJwtToken(method, path)
+            headers['Authorization'] = 'JWT {}'.format(jwtToken)
 
         return headers
+
+    def _generateJwtToken(self, method, path):
+        return atlassian_jwt.encode_token(
+            method,
+            path,
+            self.jwt_config['client_key'],
+            self.jwt_config['shared_secret'],
+            6 * 60 * 60 # timeout in seconds = 6 hours
+        )
 
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.ConnectionError, HTTPError),
@@ -88,18 +108,18 @@ class Client():
                           max_tries=6,
                           giveup=lambda e: not should_retry_httperror(e))
     def send(self, method, path, headers={}, **kwargs):
-        if self.is_cloud:
-            # OAuth Path
+        if self.is_cloud or self.jwt_config is not None:
+            # JWT or OAuth Path
             request = requests.Request(method,
                                        self.url(path),
-                                       headers=self._headers(headers),
+                                       headers=self._headers(headers, method, path),
                                        **kwargs)
         else:
             # Basic Auth Path
             request = requests.Request(method,
                                        self.url(path),
                                        auth=self.auth,
-                                       headers=self._headers(headers),
+                                       headers=self._headers(headers, method, path),
                                        **kwargs)
         return self.session.send(request.prepare())
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -1,10 +1,11 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import time
 import threading
 import re
 from requests.exceptions import HTTPError
 from requests.auth import HTTPBasicAuth
 import requests
+from requests.adapters import HTTPAdapter
 import atlassian_jwt
 from singer import metrics
 import backoff
@@ -38,6 +39,17 @@ class Client():
         self.jwt_client_key = config.get('jwt_client_key')
         self.jwt_shared_secret = config.get('jwt_shared_secret')
         self.session = requests.Session()
+        
+        # Configure connection pool for parallel bulk fetching
+        # Increase pool_connections and pool_maxsize to handle concurrent requests within each project
+        adapter = HTTPAdapter(
+            pool_connections=20,  # Number of urllib3 connection pools to cache
+            pool_maxsize=20,      # Maximum number of connections to save in the pool
+            max_retries=0         # We handle retries manually with Retry-After headers
+        )
+        self.session.mount('https://', adapter)
+        self.session.mount('http://', adapter)
+        
         self.next_request_at = datetime.now()
         self.user_agent = config.get("user_agent")
         self.login_timer = None
@@ -127,24 +139,50 @@ class Client():
                                        **kwargs)
         return self.session.send(request.prepare())
 
-    @backoff.on_exception(backoff.constant,
-                          RateLimitException,
-                          max_tries=10,
-                          interval=60)
     def request(self, tap_stream_id, *args, **kwargs):
-        wait = (self.next_request_at - datetime.now()).total_seconds()
-        if wait > 0:
-            time.sleep(wait)
-        with metrics.http_request_timer(tap_stream_id) as timer:
-            response = self.send(*args, **kwargs)
-            self.next_request_at = datetime.now() + TIME_BETWEEN_REQUESTS
-            timer.tags[metrics.Tag.http_status_code] = response.status_code
-        if response.status_code == 429:
-            raise RateLimitException()
-        elif response.text and response.status_code >= 400:
-            self.logger.warn('Response body: {}'.format(response.text))
-        response.raise_for_status()
-        return response.json()
+        max_tries = 10
+        
+        for attempt in range(max_tries):
+            # Honor rate limiting delay
+            wait = (self.next_request_at - datetime.now()).total_seconds()
+            if wait > 0:
+                time.sleep(wait)
+            
+            # Make the request
+            with metrics.http_request_timer(tap_stream_id) as timer:
+                response = self.send(*args, **kwargs)
+                self.next_request_at = datetime.now() + TIME_BETWEEN_REQUESTS
+                timer.tags[metrics.Tag.http_status_code] = response.status_code
+            
+            # Handle rate limiting (429)
+            if response.status_code == 429:
+                if attempt >= max_tries - 1:
+                    # Final attempt - give up
+                    raise RateLimitException()
+                
+                # Try to get sleep time from Retry-After header
+                retry_after = response.headers.get('Retry-After')
+                if retry_after:
+                    try:
+                        sleep_seconds = int(retry_after)
+                        self.logger.info(f"Rate limited. Waiting {sleep_seconds}s as per Retry-After header (attempt {attempt + 1}/{max_tries})")
+                    except (ValueError, TypeError):
+                        sleep_seconds = 60 * (2 ** attempt)  # Exponential backoff fallback
+                        self.logger.info(f"Rate limited. Invalid Retry-After header, using exponential backoff: {sleep_seconds}s (attempt {attempt + 1}/{max_tries})")
+                else:
+                    sleep_seconds = 60 * (2 ** attempt)  # Exponential backoff
+                    self.logger.info(f"Rate limited. Using exponential backoff: {sleep_seconds}s (attempt {attempt + 1}/{max_tries})")
+                
+                time.sleep(sleep_seconds)
+                continue
+            
+            # Log error responses for debugging
+            if response.text and response.status_code >= 400:
+                self.logger.warn('Response body: {}'.format(response.text))
+            
+            # Raise for any other HTTP errors
+            response.raise_for_status()
+            return response.json()
 
     def refresh_credentials(self):
         body = {"grant_type": "refresh_token",
@@ -167,9 +205,114 @@ class Client():
             self.login_timer.start()
 
     def test_credentials_are_authorized(self):
-        # Assume that everyone has issues, so we try and hit that endpoint
-        self.request("issues", "GET", "/rest/api/2/search",
-                     params={"maxResults": 1})
+        # Test with the new enhanced search API endpoint
+        body = {
+            "jql": "ORDER BY created DESC",
+            "maxResults": 1,
+            "fields": ["id"]
+        }
+        self.request("issues", "POST", "/rest/api/3/search/jql", json=body)
+
+    def bulk_fetch_issues(self, tap_stream_id, issue_ids, fields=None):
+        """
+        Bulk fetch issue details using the /rest/api/3/issue/bulkfetch endpoint.
+        
+        :param tap_stream_id: Stream ID for metrics
+        :param issue_ids: List of issue IDs to fetch
+        :param fields: List of fields to return (defaults to ["*all"])
+        :return: List of issue objects
+        """
+        if fields is None:
+            fields = ["*all"]
+            
+        body = {
+            "issueIdsOrKeys": issue_ids,
+            "fields": fields
+        }
+        
+        self.logger.info(f"Bulk fetching {len(issue_ids)} issues with fields: {fields}")
+        
+        response = self.request(
+            tap_stream_id,
+            "POST", 
+            "/rest/api/3/issue/bulkfetch",
+            json=body
+        )
+        
+        return response.get("issues", [])
+
+    def bulk_fetch_changelogs(self, tap_stream_id, issue_ids, field_ids=None):
+        """
+        Bulk fetch changelogs using the /rest/api/3/changelog/bulkfetch endpoint.
+        
+        :param tap_stream_id: Stream ID for metrics
+        :param issue_ids: List of issue IDs to fetch changelogs for (max 1000)
+        :param field_ids: List of field IDs to filter by (optional, max 10)
+        :return: Generator yielding changelog pages
+        """
+        if len(issue_ids) > 1000:
+            raise ValueError("Cannot fetch changelogs for more than 1000 issues at once")
+        
+        if field_ids and len(field_ids) > 10:
+            raise ValueError("Cannot filter by more than 10 field IDs")
+        
+        next_page_token = None
+        page_count = 0
+        
+        while True:
+            body = {
+                "issueIdsOrKeys": issue_ids,
+                "maxResults": 10000  # this is the max number of reults that can be fetched in one request
+            }
+            
+            if field_ids:
+                body["fieldIds"] = field_ids
+                
+            if next_page_token:
+                body["nextPageToken"] = next_page_token
+            
+            page_count += 1
+            if page_count == 1:
+                self.logger.info(f"Fetching changelogs for {len(issue_ids)} issues")
+            
+            response = self.request(
+                tap_stream_id,
+                "POST", 
+                "/rest/api/3/changelog/bulkfetch",
+                json=body
+            )
+            
+            # Extract changelogs from the bulk response structure
+            issue_change_logs = response.get("issueChangeLogs", [])
+            all_changelogs = []
+            
+            for issue_changelog in issue_change_logs:
+                issue_id = issue_changelog.get("issueId")
+                change_histories = issue_changelog.get("changeHistories", [])
+                
+                # Add issueId to each changelog entry for consistency with existing format
+                for changelog in change_histories:
+                    changelog["issueId"] = issue_id
+                    
+                    # Convert Unix timestamp (milliseconds) to ISO datetime string if needed
+                    if "created" in changelog and isinstance(changelog["created"], (int, float)):
+                        # Convert milliseconds to seconds, then to ISO format
+                        timestamp_seconds = changelog["created"] / 1000
+                        changelog["created"] = datetime.fromtimestamp(timestamp_seconds, tz=timezone.utc).isoformat()
+                    
+                    all_changelogs.append(changelog)
+            
+            if all_changelogs:
+                self.logger.info(f"Found {len(all_changelogs)} changelogs from {len(issue_change_logs)} issues in page {page_count}")
+                yield all_changelogs
+            
+            # Check for next page - break if no nextPageToken or if it's the same as previous
+            new_next_page_token = response.get("nextPageToken")
+            if not new_next_page_token or new_next_page_token == next_page_token:
+                self.logger.info(f"Completed changelog pagination after {page_count} pages for {len(issue_ids)} issues")
+                break
+            
+            next_page_token = new_next_page_token
 
 
 class Paginator():
@@ -212,3 +355,64 @@ class Paginator():
 
             if page:
                 yield page
+
+
+class EnhancedSearchPaginator():
+    """
+    Specialized paginator for the new Jira enhanced search API (/rest/api/3/search/jql).
+    Uses nextPageToken instead of startAt for pagination and POST requests with JSON bodies.
+    """
+    def __init__(self, client, max_results=100, ids_only=False):
+        self.client = client
+        self.max_results = max_results
+        self.next_page_token = None
+        self.ids_only = ids_only
+
+    def pages(self, tap_stream_id, jql, fields=None):
+        """Returns a generator which yields pages of issues from the enhanced search API.
+        
+        :param tap_stream_id: Stream ID for metrics
+        :param jql: JQL query string
+        :param fields: List of fields to return (defaults to ["*all"] unless ids_only=True)
+        """
+        # For ID-only fetches, don't specify fields for maximum performance
+        if self.ids_only:
+            fields = None
+        elif fields is None:
+            fields = ["*all"]
+
+        while True:
+            # Build the request body
+            body = {
+                "jql": jql,
+                "maxResults": self.max_results
+            }
+            
+            # Only add fields parameter if we need field data
+            if fields is not None:
+                body["fields"] = fields
+            
+            if self.next_page_token:
+                body["nextPageToken"] = self.next_page_token
+
+            # Make POST request with JSON body
+            response = self.client.request(
+                tap_stream_id, 
+                "POST", 
+                "/rest/api/3/search/jql",
+                json=body
+            )
+
+            # Extract issues from response
+            issues = response.get("issues", [])
+            
+            # Update pagination token
+            self.next_page_token = response.get("nextPageToken")
+
+            # Yield the page if it has issues
+            if issues:
+                yield issues
+
+            # Stop if no more pages
+            if not self.next_page_token:
+                break

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -7,7 +7,6 @@ from requests.auth import HTTPBasicAuth
 import requests
 import atlassian_jwt
 from singer import metrics
-import singer
 import backoff
 
 class RateLimitException(Exception):
@@ -22,7 +21,6 @@ REFRESH_TOKEN_EXPIRATION_PERIOD = 3500
 # > 10ms can help avoid performance issues
 TIME_BETWEEN_REQUESTS = timedelta(microseconds=10e3)
 
-LOGGER = singer.get_logger()
 
 def should_retry_httperror(exception):
     """ Retry 500-range errors. """
@@ -34,7 +32,8 @@ def should_retry_httperror(exception):
 
 
 class Client():
-    def __init__(self, config):
+    def __init__(self, config, logger):
+        self.logger = logger
         self.is_cloud = 'oauth_client_id' in config.keys()
         self.jwt_client_key = config.get('jwt_client_key')
         self.jwt_shared_secret = config.get('jwt_shared_secret')
@@ -44,7 +43,7 @@ class Client():
         self.login_timer = None
 
         if self.is_cloud:
-            LOGGER.info("Using OAuth based API authentication")
+            self.logger.info("Using OAuth based API authentication")
             self.auth = None
             self.base_url = 'https://api.atlassian.com/ex/jira/{}{}'
             self.cloud_id = config.get('cloud_id')
@@ -59,11 +58,11 @@ class Client():
             self.refresh_credentials()
             self.test_credentials_are_authorized()
         elif self.jwt_client_key is not None:
-            LOGGER.info("Using JWT API authentication")
+            self.logger.info("Using JWT API authentication")
             self.base_url = config.get("base_url")
             self.auth = None
         else:
-            LOGGER.info("Using Basic Auth API authentication")
+            self.logger.info("Using Basic Auth API authentication")
             self.base_url = config.get("base_url")
             self.auth = HTTPBasicAuth(config.get("username"), config.get("password"))
 
@@ -143,7 +142,7 @@ class Client():
         if response.status_code == 429:
             raise RateLimitException()
         elif response.text and response.status_code >= 400:
-            LOGGER.warn('Response body: {}'.format(response.text))
+            self.logger.warn('Response body: {}'.format(response.text))
         response.raise_for_status()
         return response.json()
 
@@ -162,7 +161,7 @@ class Client():
                 error_message = error_message + ", Response from Jira: {}".format(resp.text)
             raise Exception(error_message) from ex
         finally:
-            LOGGER.info("Starting new login timer")
+            self.logger.info("Starting new login timer")
             self.login_timer = threading.Timer(REFRESH_TOKEN_EXPIRATION_PERIOD,
                                                self.refresh_credentials)
             self.login_timer.start()

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -119,7 +119,7 @@ class Client():
         )
 
     @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError, HTTPError),
+                          (requests.exceptions.ConnectionError, requests.exceptions.ChunkedEncodingError, HTTPError),
                           jitter=None,
                           max_tries=6,
                           giveup=lambda e: not should_retry_httperror(e))

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -23,15 +23,6 @@ REFRESH_TOKEN_EXPIRATION_PERIOD = 3500
 TIME_BETWEEN_REQUESTS = timedelta(microseconds=10e3)
 
 
-def should_retry_httperror(exception):
-    """ Retry 500-range errors. """
-    # An ConnectionError is thrown without a response
-    if exception.response is None:
-        return True
-
-    return 500 <= exception.response.status_code < 600
-
-
 class Client():
     def __init__(self, config, logger):
         self.logger = logger
@@ -118,11 +109,6 @@ class Client():
             6 * 60 * 60 # timeout in seconds = 6 hours
         )
 
-    @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError, requests.exceptions.ChunkedEncodingError, HTTPError),
-                          jitter=None,
-                          max_tries=6,
-                          giveup=lambda e: not should_retry_httperror(e))
     def send(self, method, path, headers={}, **kwargs):
         if self.is_cloud or self.jwt_client_key is not None:
             # JWT or OAuth Path
@@ -139,50 +125,54 @@ class Client():
                                        **kwargs)
         return self.session.send(request.prepare())
 
+    @backoff.on_exception(backoff.expo,
+                          (requests.exceptions.ConnectionError,
+                           requests.exceptions.ChunkedEncodingError,
+                           HTTPError,
+                           RateLimitException),
+                          jitter=None,
+                          max_tries=10,
+                          giveup=lambda e: isinstance(e, HTTPError) and
+                                          e.response is not None and
+                                          not (500 <= e.response.status_code < 600))
     def request(self, tap_stream_id, *args, **kwargs):
-        max_tries = 10
-        
-        for attempt in range(max_tries):
-            # Honor rate limiting delay
-            wait = (self.next_request_at - datetime.now()).total_seconds()
-            if wait > 0:
-                time.sleep(wait)
-            
-            # Make the request
-            with metrics.http_request_timer(tap_stream_id) as timer:
-                response = self.send(*args, **kwargs)
-                self.next_request_at = datetime.now() + TIME_BETWEEN_REQUESTS
-                timer.tags[metrics.Tag.http_status_code] = response.status_code
-            
-            # Handle rate limiting (429)
-            if response.status_code == 429:
-                if attempt >= max_tries - 1:
-                    # Final attempt - give up
-                    raise RateLimitException()
-                
-                # Try to get sleep time from Retry-After header
-                retry_after = response.headers.get('Retry-After')
-                if retry_after:
-                    try:
-                        sleep_seconds = int(retry_after)
-                        self.logger.info(f"Rate limited. Waiting {sleep_seconds}s as per Retry-After header (attempt {attempt + 1}/{max_tries})")
-                    except (ValueError, TypeError):
-                        sleep_seconds = 60 * (2 ** attempt)  # Exponential backoff fallback
-                        self.logger.info(f"Rate limited. Invalid Retry-After header, using exponential backoff: {sleep_seconds}s (attempt {attempt + 1}/{max_tries})")
-                else:
-                    sleep_seconds = 60 * (2 ** attempt)  # Exponential backoff
-                    self.logger.info(f"Rate limited. Using exponential backoff: {sleep_seconds}s (attempt {attempt + 1}/{max_tries})")
-                
-                time.sleep(sleep_seconds)
-                continue
-            
-            # Log error responses for debugging
-            if response.text and response.status_code >= 400:
-                self.logger.warn('Response body: {}'.format(response.text))
-            
-            # Raise for any other HTTP errors
-            response.raise_for_status()
-            return response.json()
+        # Honor rate limiting delay
+        wait = (self.next_request_at - datetime.now()).total_seconds()
+        if wait > 0:
+            time.sleep(wait)
+
+        # Make the request
+        with metrics.http_request_timer(tap_stream_id) as timer:
+            response = self.send(*args, **kwargs)
+            self.next_request_at = datetime.now() + TIME_BETWEEN_REQUESTS
+            timer.tags[metrics.Tag.http_status_code] = response.status_code
+
+        # Handle rate limiting (429) with custom logic
+        if response.status_code == 429:
+            # Try to get sleep time from Retry-After header
+            retry_after = response.headers.get('Retry-After')
+            if retry_after:
+                try:
+                    sleep_seconds = int(retry_after)
+                    self.logger.info(f"Rate limited. Waiting {sleep_seconds}s as per Retry-After header")
+                except (ValueError, TypeError):
+                    sleep_seconds = 60  # Default fallback
+                    self.logger.info(f"Rate limited. Invalid Retry-After header, waiting {sleep_seconds}s")
+            else:
+                sleep_seconds = 60  # Default wait time
+                self.logger.info(f"Rate limited. No Retry-After header, waiting {sleep_seconds}s")
+
+            time.sleep(sleep_seconds)
+            # Raise exception to trigger backoff decorator retry
+            raise RateLimitException()
+
+        # Log error responses for debugging
+        if response.text and response.status_code >= 400:
+            self.logger.warn('Response body: {}'.format(response.text))
+
+        # Raise for any HTTP errors (backoff decorator will handle 5xx retries)
+        response.raise_for_status()
+        return response.json()
 
     def refresh_credentials(self):
         body = {"grant_type": "refresh_token",
@@ -229,7 +219,7 @@ class Client():
             "issueIdsOrKeys": issue_ids,
             "fields": fields
         }
-        
+
         self.logger.info(f"Bulk fetching {len(issue_ids)} issues with fields: {fields}")
         
         response = self.request(

--- a/tap_jira/schemas/boards.json
+++ b/tap_jira/schemas/boards.json
@@ -1,0 +1,83 @@
+{
+  "title": "Board",
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "id": {
+      "type": [
+        "integer"
+      ]
+    },
+    "self": {
+      "type": [
+        "null",
+        "string"
+      ],
+      "format": "uri"
+    },
+    "name": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "type": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "location": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "projectId": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "displayName": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "projectName": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "projectKey": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "projectTypeKey": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "avatarURI": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tap_jira/schemas/changelogs.json
+++ b/tap_jira/schemas/changelogs.json
@@ -45,6 +45,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",
@@ -122,6 +128,12 @@
               "string"
             ]
           },
+          "tmpFromAccountId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "from": {
             "type": [
               "null",
@@ -129,6 +141,12 @@
             ]
           },
           "fromString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tmpToAccountId": {
             "type": [
               "null",
               "string"

--- a/tap_jira/schemas/issue_comments.json
+++ b/tap_jira/schemas/issue_comments.json
@@ -141,6 +141,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",

--- a/tap_jira/schemas/issue_transitions.json
+++ b/tap_jira/schemas/issue_transitions.json
@@ -125,6 +125,18 @@
         "boolean"
       ]
     },
+    "isAvailable": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "isLooped": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
     "isInitial": {
       "type": [
         "null",

--- a/tap_jira/schemas/issues.json
+++ b/tap_jira/schemas/issues.json
@@ -445,138 +445,21 @@
           ]
         },
 
-        "customfield_10000": {
-          "title": "development",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10001": {
-          "title": "team",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10002": {
-          "title": "organizations",
-          "__COMMENT": "not sure of data type, don't import yet",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10003": {
-          "title": "approvers",
-          "__COMMENT": "actually an array of users, don't import yet",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10004": {
-          "title": "impact",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10005": {
-          "title": "changetype",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10006": {
-          "title": "changerisk",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10007": {
-          "title": "changereason",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10008": {
-          "title": "actualstart",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10009": {
-          "title": "actualend",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10010": {
-          "title": "requesttype",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10011": {
-          "title": "epicname",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10012": {
-          "title": "epicstatus",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10013": {
-          "title": "epiccolor",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10014": {
+        "Epic Link": {
           "title": "epiclink",
           "type": [
             "null",
             "string"
           ]
         },
-        "customfield_10015": {
-          "title": "startdate",
+        "Story Points": {
+          "title": "storypoints",
           "type": [
             "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10016": {
-          "title": "storypointestimate",
-          "type": [
-            "null",
-            "string"
+            "number"
           ]
         },
-        "customfield_10017": {
-          "title": "issuecolor",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10018": {
+        "Parent Link": {
           "title": "parentlink",
           "type": [
             "null",
@@ -586,14 +469,14 @@
             ".+": {}
           }
         },
-        "customfield_10019": {
+        "Rank": {
           "title": "rank",
           "type": [
             "null",
             "string"
           ]
         },
-        "customfield_10020": {
+        "Sprint": {
           "title": "sprint",
           "type": [
             "null",
@@ -603,65 +486,15 @@
             "$ref": "sprint"
           }
         },
-        "customfield_10021": {
-          "title": "flagged",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10022": {
-          "title": "targetstart",
+        "_custom": {
+          "title": "othercustomfields",
           "type": [
             "null",
             "string"
           ],
-          "format": "date-time"
-        },
-        "customfield_10023": {
-          "title": "targetend",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10024": {
-          "title": "dateoffirstresponse",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-
-        "customfield_10025": {
-          "title": "timeinstatus",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10026": {
-          "title": "storypoints",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10027": {
-          "title": "uuid",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10028": {
-          "title": "location",
-          "type": [
-            "null",
-            "string"
-          ]
+          "patternProperties": {
+            ".+": {}
+          }
         }
       },
       "patternProperties": {
@@ -914,6 +747,13 @@
             "string"
           ],
           "format": "date-time"
+        },
+        "completeDate": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
         }
       }
     },
@@ -990,6 +830,12 @@
           ]
         },
         "accountId": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "accountType": {
           "type": [
             "null",
             "string"
@@ -1150,6 +996,12 @@
           "format": "uri"
         },
         "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "description": {
           "type": [
             "null",
             "string"
@@ -1392,6 +1244,9 @@
           ]
         },
         "inwardIssue": {
+          "$ref": "issuestub"
+        },
+        "outwardIssue": {
           "$ref": "issuestub"
         }
       }

--- a/tap_jira/schemas/issues.json
+++ b/tap_jira/schemas/issues.json
@@ -626,6 +626,12 @@
             "string"
           ]
         },
+        "entityId": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "description": {
           "type": [
             "null",
@@ -937,6 +943,12 @@
           ]
         },
         "projectTypeKey": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "projectCategory": {
           "type": [
             "null",
             "string"

--- a/tap_jira/schemas/issues.json
+++ b/tap_jira/schemas/issues.json
@@ -166,6 +166,502 @@
           "items": {
             "$ref": "attachment"
           }
+        },
+        "issuetype": {
+          "$ref": "issuetype"
+        },
+
+        "timespent": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "project": {
+          "$ref": "project"
+        },
+        "aggregatetimespent": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "workratio": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "timeestimate": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "aggregatetimeoriginalestimate": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "timeoriginalestimate": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "aggregatetimeestimate": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+
+        "resolution": {
+          "$ref": "resolution"
+        },
+        "resolutiondate": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "fixVersions": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "fixversion"
+          }
+        },
+        "versions": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "patternProperties": {
+              ".+": {}
+            }
+          }
+        },
+        "priority": {
+          "type": [
+            "null",
+            "object"
+          ],
+          "properties": {
+            "self": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "uri"
+            },
+            "iconUrl": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "uri"
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          }
+        },
+        "labels": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "type": [
+              "null",
+              "string"
+            ]
+          }
+        },
+        "issuelinks": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "issuelink"
+          }
+        },
+        "assignee": {
+          "$ref": "user"
+        },
+        "status": {
+          "$ref": "status"
+        },
+        "components": {
+          "items": {
+            "$ref": "component"
+          },
+          "type": [
+            "null",
+            "array"
+          ]
+        },
+        "summary": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "timetracking": {
+          "properties": {
+            "originalEstimate": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "remainingEstimate": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "timeSpent": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "originalEstimateSeconds": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "remainingEstimateSeconds": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "timeSpentSeconds": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "security": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "creator": {
+          "$ref": "user"
+        },
+        "reporter": {
+          "$ref": "user"
+        },
+        "subtasks": {
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "issuestub"
+          }
+        },
+        "aggregateprogress": {
+          "$ref": "progress"
+        },
+        "progress": {
+          "$ref": "progress"
+        },
+        "environment": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "duedate": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date"
+        },
+        "votes": {
+          "properties": {
+            "self": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "uri"
+            },
+            "votes": {
+              "type": [
+                "null",
+                "integer"
+              ]
+            },
+            "hasVoted": {
+              "type": [
+                "null",
+                "boolean"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+
+        "customfield_10000": {
+          "title": "development",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10001": {
+          "title": "team",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10002": {
+          "title": "organizations",
+          "__COMMENT": "not sure of data type, don't import yet",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10003": {
+          "title": "approvers",
+          "__COMMENT": "actually an array of users, don't import yet",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10004": {
+          "title": "impact",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10005": {
+          "title": "changetype",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10006": {
+          "title": "changerisk",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10007": {
+          "title": "changereason",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10008": {
+          "title": "actualstart",
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "customfield_10009": {
+          "title": "actualend",
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "customfield_10010": {
+          "title": "requesttype",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10011": {
+          "title": "epicname",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10012": {
+          "title": "epicstatus",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10013": {
+          "title": "epiccolor",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10014": {
+          "title": "epiclink",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10015": {
+          "title": "startdate",
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "customfield_10016": {
+          "title": "storypointestimate",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10017": {
+          "title": "issuecolor",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10018": {
+          "title": "parentlink",
+          "type": [
+            "null",
+            "object"
+          ],
+          "patternProperties": {
+            ".+": {}
+          }
+        },
+        "customfield_10019": {
+          "title": "rank",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10020": {
+          "title": "sprint",
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "sprint"
+          }
+        },
+        "customfield_10021": {
+          "title": "flagged",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10022": {
+          "title": "targetstart",
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "customfield_10023": {
+          "title": "targetend",
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "customfield_10024": {
+          "title": "dateoffirstresponse",
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+
+        "customfield_10025": {
+          "title": "timeinstatus",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10026": {
+          "title": "storypoints",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10027": {
+          "title": "uuid",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "customfield_10028": {
+          "title": "location",
+          "type": [
+            "null",
+            "string"
+          ]
         }
       },
       "patternProperties": {
@@ -278,6 +774,149 @@
         }
       }
     },
+    "issuetype": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "self": {
+          "format": "uri",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "iconUrl": {
+          "format": "uri",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "subtask": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "avatarId": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "hierarchyLevel": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        }
+      }
+    },
+    "resolution": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "self": {
+          "format": "uri",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      }
+    },
+    "sprint": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "state": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "boardId": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "goal": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "startDate": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        },
+        "endDate": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
+        }
+      }
+    },
     "simple-link": {
       "title": "Simple Link",
       "type": [
@@ -329,13 +968,318 @@
         }
       }
     },
+    "user": {
+      "properties": {
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "self": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "uri"
+        },
+        "timeZone": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "accountId": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "active": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "key": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "avatarUrls": {
+          "properties": {
+            "16x16": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "24x24": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "48x48": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "32x32": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "emailAddress": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "displayName": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "project": {
+      "properties": {
+        "self": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "uri"
+        },
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "key": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "projectTypeKey": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "simplified": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "avatarUrls": {
+          "properties": {
+            "16x16": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "24x24": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "48x48": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "32x32": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        }
+      },
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "component": {
+      "properties": {
+        "self": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "uri"
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "progress": {
+      "properties": {
+        "progress": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "total": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        },
+        "percent": {
+          "type": [
+            "null",
+            "integer"
+          ]
+        }
+      },
+      "type": [
+        "null",
+        "object"
+      ]
+    },
+    "status": {
+      "properties": {
+        "self": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "uri"
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "iconUrl": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "uri"
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "statusCategory": {
+          "properties": {
+            "self": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "uri"
+            },
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "key": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "colorName": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        }
+      },
+      "type": [
+        "null",
+        "object"
+      ]
+    },
     "attachment": {
       "properties": {
         "self": {
           "type": [
             "null",
             "string"
-          ]
+          ],
+          "format": "uri"
         },
         "thumbnail": {
           "type": [
@@ -363,92 +1307,7 @@
           ]
         },
         "author": {
-          "properties": {
-            "name": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "self": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "timeZone": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "accountId": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "active": {
-              "type": [
-                "null",
-                "boolean"
-              ]
-            },
-            "key": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "avatarUrls": {
-              "properties": {
-                "16x16": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                "24x24": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                "48x48": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                },
-                "32x32": {
-                  "type": [
-                    "null",
-                    "string"
-                  ]
-                }
-              },
-              "type": [
-                "null",
-                "object"
-              ]
-            },
-            "emailAddress": {
-              "type": [
-                "null",
-                "string"
-              ]
-            },
-            "displayName": {
-              "type": [
-                "null",
-                "string"
-              ]
-            }
-          },
-          "type": [
-            "null",
-            "object"
-          ]
+          "$ref": "user"
         },
         "size": {
           "type": [
@@ -473,6 +1332,144 @@
         "null",
         "object"
       ]
+    },
+    "issuelink": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "self": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "uri"
+        },
+        "type": {
+          "properties": {
+            "id": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "name": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "inward": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "outward": {
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            "self": {
+              "type": [
+                "null",
+                "string"
+              ],
+              "format": "uri"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "inwardIssue": {
+          "$ref": "issuestub"
+        }
+      }
+    },
+    "issuestub": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "key": {
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "patternProperties": {
+        ".+": {}
+      }
+    },
+    "fixversion": {
+      "type": [
+        "null",
+        "object"
+      ],
+      "properties": {
+        "id": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "self": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "uri"
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "archived": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "released": {
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
+        "releaseDate": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date"
+        }
+      }
     }
   }
 }

--- a/tap_jira/schemas/priorities.json
+++ b/tap_jira/schemas/priorities.json
@@ -26,7 +26,7 @@
       "description": "The ID of the issue priority."
     },
     "isDefault": {
-      "type": "boolean",
+      "type": ["boolean", "null"],
       "description": "Whether this priority is the default."
     }
   },

--- a/tap_jira/schemas/priorities.json
+++ b/tap_jira/schemas/priorities.json
@@ -1,0 +1,35 @@
+{
+  "type": ["null", "object"],
+  "properties": {
+    "self": {
+      "type": "string",
+      "description": "The URL of the issue priority."
+    },
+    "statusColor": {
+      "type": "string",
+      "description": "The color used to indicate the issue priority."
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the issue priority."
+    },
+    "iconUrl": {
+      "type": "string",
+      "description": "The URL of the icon for the issue priority."
+    },
+    "name": {
+      "type": "string",
+      "description": "The name of the issue priority."
+    },
+    "id": {
+      "type": "string",
+      "description": "The ID of the issue priority."
+    },
+    "isDefault": {
+      "type": "boolean",
+      "description": "Whether this priority is the default."
+    }
+  },
+  "additionalProperties": true,
+  "description": "An issue priority."
+}

--- a/tap_jira/schemas/projects.json
+++ b/tap_jira/schemas/projects.json
@@ -385,6 +385,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "name": {
           "type": [
             "null",

--- a/tap_jira/schemas/projects_normalized.json
+++ b/tap_jira/schemas/projects_normalized.json
@@ -1,0 +1,32 @@
+{
+  "title": "Project Normalized",
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+
+    "id": {
+      "type": [
+        "string"
+      ]
+    },
+    "name": {
+      "type": [
+        "string"
+      ]
+    },
+    "description": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "url": {
+      "type": [
+        "null",
+        "string"
+      ]
+    }
+  }
+}

--- a/tap_jira/schemas/users.json
+++ b/tap_jira/schemas/users.json
@@ -24,6 +24,12 @@
         "string"
       ]
     },
+    "accountType": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "name": {
       "type": [
         "null",

--- a/tap_jira/schemas/worklogs.json
+++ b/tap_jira/schemas/worklogs.json
@@ -149,6 +149,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",

--- a/tap_jira/schemas/worklogs_deleted.json
+++ b/tap_jira/schemas/worklogs_deleted.json
@@ -1,0 +1,42 @@
+{
+  "title": "Worklog Deleted",
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "worklogId": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "updatedTime": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "properties": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "key": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "value": {}
+        }
+      }
+    }
+  }
+}

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -75,21 +75,14 @@ def sync_sub_streams(page, issue_changelog_updated):
                 for changelog in changelogs:
                     changelogs_to_write.append(changelog)
             else:
-                pager = Paginator(Context.client, order_by="sequence")
-                fetch_more_changelogs = True
+                pager = Paginator(Context.client)
                 for page in pager.pages(
                     CHANGELOGS.tap_stream_id,
                     "GET",
                     "/rest/api/2/issue/{}/changelog".format(issue["id"])
                 ):
                     for changelog in page:
-                        if utils.strptime_to_utc(changelog["created"]) < issue_changelog_updated:
-                            fetch_more_changelogs = False
-
                         changelogs_to_write.append(changelog)
-
-                    if not fetch_more_changelogs:
-                        break
 
             CHANGELOGS.write_page(
                 [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
@@ -373,12 +366,17 @@ class Issues(Stream):
         last_updated = Context.update_start_date_bookmark(updated_bookmark)
         timezone = Context.retrieve_timezone()
         start_date = last_updated.astimezone(pytz.timezone(timezone)).strftime("%Y-%m-%d %H:%M")
-        if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < last_updated < datetime.datetime(2024, 7, 23, 5, 0, 0, tzinfo=pytz.utc):
+        if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < last_updated < datetime.datetime(2024, 8, 10, 5, 0, 0, tzinfo=pytz.utc):
             LOGGER.info('state is in broken timeframe, going back in time to ensure all issues are ingested')
             start_date = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc).strftime("%Y-%m-%d %H:%M")
 
         issue_changelogs_updated_bookmark_path = [CHANGELOGS.tap_stream_id, project_key_or_id, "updated"]
         issue_changelogs_updated = Context.update_start_date_bookmark(issue_changelogs_updated_bookmark_path)
+        if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < issue_changelogs_updated < datetime.datetime(2024, 8, 10, 5, 0, 0, tzinfo=pytz.utc):
+            LOGGER.info('changelog state is in broken timeframe, going back in time to ensure all issues are ingested')
+            start_date = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc).strftime("%Y-%m-%d %H:%M")
+            issue_changelogs_updated = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc)
+
         # grab the time now, before we sync any changelogs
         # this will be used later to bookmark our progress
         # there will be some overlap during the sync, but this allows us to avoid saving state per issue

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -232,23 +232,24 @@ class Issues(Stream):
         timezone = Context.retrieve_timezone()
         start_date = last_updated.astimezone(pytz.timezone(timezone)).strftime("%Y-%m-%d %H:%M")
 
-        # First, fetch all the custom field names for translation
-        page_num = 0
-        fieldPager = Paginator(Context.client, page_num=page_num, items_key=None)
-        params = {
-            "maxResults": 100,
-        }
-        fieldNames = {}
-        for page in fieldPager.pages('issue_fields', "GET", "/rest/api/2/field", params=params):
-            for field in page:
-                id = field['id']
-                name = field['name']
-                fieldNames[id] = name
-            # HACK - there should only be one page, not sure why pager doesn't support this
-            break
-
         stream = Context.get_catalog_entry(self.tap_stream_id)
         knownFields = stream.schema.properties['fields'].properties
+
+        # First, fetch all the custom field names for translation
+        fieldNames = {}
+        fields = []
+        for field in Context.client.request('issue_fields', "GET", "/rest/api/2/field"):
+            fields.append(field)
+
+        sortedFields = sorted(fields, key=lambda f: f['custom'], reverse=False)
+        for field in sortedFields:
+            id = field['id']
+            name = field['name']
+
+            if name in fieldNames.values():
+                name += '_' + field['id'].replace('customfield_', '')
+
+            fieldNames[id] = name
 
         # build projects filter from config, if any
         projectsList = Context.get_projects()
@@ -284,21 +285,15 @@ class Issues(Stream):
                 issue['fields'].pop('operations', None)
 
                 # Rename all of the custom fields
-                issueKeys = []
-                for k in issue['fields'].keys():
-                    issueKeys.append(k)
-                for k in issueKeys:
+                for k in list(issue['fields'].keys()):
                     if k[:len('customfield_')] == 'customfield_':
                         val = issue['fields'][k]
                         del issue['fields'][k]
                         issue['fields'][fieldNames[k]] = val
 
                 # Now, go through and separate fields we don't recognize into "_custom"
-                issueKeys = []
                 customFields = {}
-                for k in issue['fields'].keys():
-                    issueKeys.append(k)
-                for k in issueKeys:
+                for k in list(issue['fields'].keys()):
                     # If we don't know about this field, then put it in a "_custom" object for
                     # outputting as a single JSON
                     if not k in knownFields:

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -266,7 +266,7 @@ class Issues(Stream):
             # with each other as well as system fields.
             # If we run into this problem, we append the customfields
             # numeric id to the name to avoid collisions
-            if name in fieldNames.values():
+            if name in fieldNames.values() or name in knownFields.keys():
                 name += '_' + field['id'].replace('customfield_', '')
 
             fieldNames[id] = name

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -347,6 +347,7 @@ ALL_STREAMS = [
     Stream("project_categories", ["id"], path="/rest/api/2/projectCategory"),
     Stream("resolutions", ["id"], path="/rest/api/2/resolution"),
     Stream("roles", ["id"], path="/rest/api/2/role"),
+    Stream("priorities", ["id"], path="/rest/api/2/priority"),
     Users("users", ["accountId"]),
     ISSUES,
     ISSUE_COMMENTS,

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -241,11 +241,18 @@ class Issues(Stream):
         for field in Context.client.request('issue_fields', "GET", "/rest/api/2/field"):
             fields.append(field)
 
+        # When generating fieldNames, we need to get all the system fields first
+        # In the event that customfields_* has an identical name to a system field,
+        # we need to make sure we do not overwrite the system field with the customfields value
         sortedFields = sorted(fields, key=lambda f: f['custom'], reverse=False)
         for field in sortedFields:
             id = field['id']
             name = field['name']
 
+            # JIRA does allow custommfields to have names that conflict
+            # with each other as well as system fields.
+            # If we run into this problem, we append the customfields
+            # numeric id to the name to avoid collisions
             if name in fieldNames.values():
                 name += '_' + field['id'].replace('customfield_', '')
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -125,7 +125,7 @@ class Projects(Stream):
         # apply projects filter if applicable
         projectsFilter = Context.get_projects()
         if len(projectsFilter) > 0:
-            projects = list(filter(lambda p: p["key"] in projectsFilter, projects))
+            projects = list(filter(lambda p: p["key"] in projectsFilter or p["id"] in projectsFilter, projects))
 
         for project in projects:
             # The Jira documentation suggests that a "versions" key may appear

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -368,16 +368,6 @@ class Worklogs(Stream):
 
 
 class WorklogsDeleted(Stream):
-    def _fetch_records(self, last_updated):
-        # since_ts uses millisecond precision
-        since_ts = int(last_updated.timestamp()) * 1000
-        return Context.client.request(
-            self.tap_stream_id,
-            "GET",
-            "/rest/api/2/worklog/deleted",
-            params={"since": since_ts},
-        )
-
     def sync(self):
         updated_bookmark = [self.tap_stream_id, "updated"]
         last_updated = Context.update_start_date_bookmark(updated_bookmark)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -57,18 +57,51 @@ def raise_if_bookmark_cannot_advance(worklogs):
                         .format(worklog_updatedes[0]))
 
 
-def sync_sub_streams(page):
+def sync_sub_streams(page, issue_changelog_updated):
     for issue in page:
         comments = issue["fields"].pop("comment")["comments"]
         if comments and Context.is_selected(ISSUE_COMMENTS.tap_stream_id):
             for comment in comments:
                 comment["issueId"] = issue["id"]
             ISSUE_COMMENTS.write_page(comments)
-        changelogs = issue.pop("changelog")["histories"]
-        if changelogs and Context.is_selected(CHANGELOGS.tap_stream_id):
-            for changelog in changelogs:
-                changelog["issueId"] = issue["id"]
-            CHANGELOGS.write_page(changelogs)
+
+        if Context.is_selected(CHANGELOGS.tap_stream_id):
+            changelog_response = issue.pop("changelog")
+            changelogs = changelog_response["histories"]
+            if any(
+                utils.strptime_to_utc(changelog["created"]) >= issue_changelog_updated \
+                    for changelog in changelogs
+            ):
+                changelogs_to_write = []
+
+                # when expanding changelogs for an issue, jira returns 100
+                if changelog_response['maxResults'] >= changelog_response['total']:
+                    for changelog in changelogs:
+                        if utils.strptime_to_utc(changelog["created"]) > issue_changelog_updated:
+                            break
+
+                        changelogs_to_write.append(changelog)
+                else:
+                    pager = Paginator(Context.client, order_by="sequence")
+                    fetch_more_changelogs = True
+                    for page in pager.pages(
+                        CHANGELOGS.tap_stream_id,
+                        "GET",
+                        "/rest/api/2/issue/{}/changelog".format(issue["id"])
+                    ):
+                        for changelog in page:
+                            if utils.strptime_to_utc(changelog["created"]) < issue_changelog_updated:
+                                fetch_more_changelogs = False
+
+                            changelogs_to_write.append(changelog)
+
+                        if not fetch_more_changelogs:
+                            break
+
+                CHANGELOGS.write_page(
+                    [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
+                )
+
         transitions = issue.pop("transitions")
         if transitions and Context.is_selected(ISSUE_TRANSITIONS.tap_stream_id):
             for transition in transitions:
@@ -288,10 +321,18 @@ class Issues(Stream):
                 self.sync_project(fieldNames, knownFields)
         else:
             with ThreadPoolExecutor(max_workers=6) as executor:
+                func_call_futures = []
                 for project_key_or_id in projectsToSync:
                     ctx = contextvars.copy_context()
                     func_call = functools.partial(ctx.run, self.sync_project, fieldNames, knownFields, project_key_or_id)
-                    executor.submit(func_call)
+                    func_call_futures.append(executor.submit(func_call))
+
+                ## bubble up any exceptions discovered while syncing a project
+                try:
+                    for func_call_future in func_call_futures:
+                        func_call_future.result()
+                except Exception as ex:
+                    LOGGER.exception(ex)
         
         self.delete_old_state()
 
@@ -336,6 +377,13 @@ class Issues(Stream):
         timezone = Context.retrieve_timezone()
         start_date = last_updated.astimezone(pytz.timezone(timezone)).strftime("%Y-%m-%d %H:%M")
 
+        issue_changelogs_updated_bookmark_path = [CHANGELOGS.tap_stream_id, project_key_or_id, "updated"]
+        issue_changelogs_updated = Context.update_start_date_bookmark(issue_changelogs_updated_bookmark_path)
+        # grab the time now, before we sync any changelogs
+        # this will be used later to bookmark our progress
+        # there will be some overlap during the sync, but this allows us to avoid saving state per issue
+        issue_changelogs_sync_time = utils.now()
+
         LOGGER.info('using updated >= \'{}\''.format(start_date))
 
         # Now fetch all the actual issues, translating custom fields
@@ -351,7 +399,7 @@ class Issues(Stream):
                                 "GET", "/rest/api/2/search",
                                 params=params):
             # sync comments and changelogs for each issue
-            sync_sub_streams(page)
+            sync_sub_streams(page, issue_changelogs_updated)
             for issue in page:
                 issue['fields'].pop('worklog', None)
                 # The JSON schema for the search endpoint indicates an "operations"
@@ -395,6 +443,7 @@ class Issues(Stream):
         with self.write_lock:
             Context.set_bookmark(page_num_offset, None)
             Context.set_bookmark(updated_bookmark, last_updated)
+            Context.set_bookmark(issue_changelogs_updated_bookmark_path, issue_changelogs_sync_time)
             singer.write_state(Context.state)
 
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -294,7 +294,7 @@ class Issues(Stream):
         if not project_page_num_offset and not project_updated_bookmark:
             non_project_updated_bookmark_key = [self.tap_stream_id, "updated"]
             non_project_updated_bookmark = Context.bookmark(non_project_updated_bookmark_key)
-            LOGGER.info('Previous state found {}: {}, {}'.format('.'.join(non_project_updated_bookmark_key), non_project_updated_bookmark, Context.bookmarks()))
+            LOGGER.info('Previous state found {}: {}'.format('.'.join(non_project_updated_bookmark_key), non_project_updated_bookmark))
             if non_project_updated_bookmark:
                 LOGGER.info('Updated being copied from previous state format')
                 Context.set_bookmark(updated_bookmark, non_project_updated_bookmark)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -68,39 +68,32 @@ def sync_sub_streams(page, issue_changelog_updated):
         if Context.is_selected(CHANGELOGS.tap_stream_id):
             changelog_response = issue.pop("changelog")
             changelogs = changelog_response["histories"]
-            if any(
-                utils.strptime_to_utc(changelog["created"]) >= issue_changelog_updated \
-                    for changelog in changelogs
-            ):
-                changelogs_to_write = []
+            changelogs_to_write = []
 
-                # when expanding changelogs for an issue, jira returns 100
-                if changelog_response['maxResults'] >= changelog_response['total']:
-                    for changelog in changelogs:
-                        if utils.strptime_to_utc(changelog["created"]) > issue_changelog_updated:
-                            break
+            # when expanding changelogs for an issue, jira returns 100
+            if changelog_response['maxResults'] >= changelog_response['total']:
+                for changelog in changelogs:
+                    changelogs_to_write.append(changelog)
+            else:
+                pager = Paginator(Context.client, order_by="sequence")
+                fetch_more_changelogs = True
+                for page in pager.pages(
+                    CHANGELOGS.tap_stream_id,
+                    "GET",
+                    "/rest/api/2/issue/{}/changelog".format(issue["id"])
+                ):
+                    for changelog in page:
+                        if utils.strptime_to_utc(changelog["created"]) < issue_changelog_updated:
+                            fetch_more_changelogs = False
 
                         changelogs_to_write.append(changelog)
-                else:
-                    pager = Paginator(Context.client, order_by="sequence")
-                    fetch_more_changelogs = True
-                    for page in pager.pages(
-                        CHANGELOGS.tap_stream_id,
-                        "GET",
-                        "/rest/api/2/issue/{}/changelog".format(issue["id"])
-                    ):
-                        for changelog in page:
-                            if utils.strptime_to_utc(changelog["created"]) < issue_changelog_updated:
-                                fetch_more_changelogs = False
 
-                            changelogs_to_write.append(changelog)
+                    if not fetch_more_changelogs:
+                        break
 
-                        if not fetch_more_changelogs:
-                            break
-
-                CHANGELOGS.write_page(
-                    [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
-                )
+            CHANGELOGS.write_page(
+                [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
+            )
 
         transitions = issue.pop("transitions")
         if transitions and Context.is_selected(ISSUE_TRANSITIONS.tap_stream_id):
@@ -376,6 +369,9 @@ class Issues(Stream):
         last_updated = Context.update_start_date_bookmark(updated_bookmark)
         timezone = Context.retrieve_timezone()
         start_date = last_updated.astimezone(pytz.timezone(timezone)).strftime("%Y-%m-%d %H:%M")
+        if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < last_updated < datetime.datetime(2024, 7, 23, 5, 0, 0, tzinfo=pytz.utc):
+            LOGGER.info('state is in broken timeframe, going back in time to ensure all issues are ingested')
+            start_date = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc).strftime("%Y-%m-%d %H:%M")
 
         issue_changelogs_updated_bookmark_path = [CHANGELOGS.tap_stream_id, project_key_or_id, "updated"]
         issue_changelogs_updated = Context.update_start_date_bookmark(issue_changelogs_updated_bookmark_path)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -151,6 +151,16 @@ class ProjectTypes(Stream):
         self.write_page(types)
 
 
+class Boards(Stream):
+    def sync(self):
+        path = "/rest/agile/1.0/board"
+        # Just do full sync each time for now
+        params = {}
+        pager = Paginator(Context.client, items_key='values')
+        for page in pager.pages(self.tap_stream_id, "GET", path, params=params):
+            self.write_page(page)
+
+
 class Users(Stream):
     def sync(self):
         max_results = 2
@@ -333,6 +343,7 @@ ALL_STREAMS = [
     VERSIONS,
     COMPONENTS,
     ProjectTypes("project_types", ["key"]),
+    Boards("boards", ["id"]),
     Stream("project_categories", ["id"], path="/rest/api/2/projectCategory"),
     Stream("resolutions", ["id"], path="/rest/api/2/resolution"),
     Stream("roles", ["id"], path="/rest/api/2/role"),

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -366,9 +366,19 @@ class Issues(Stream):
         project_updated_bookmark = Context.bookmark(updated_bookmark)
         project_page_num_offset = Context.bookmark(page_num_offset)
 
+        # check if project_page_num_offset is a Dict
+        # we are getting an exception below with the logger call 
+        # when the value is not iterable
+        if not isinstance(project_page_num_offset, dict):
+            project_page_num_offset_for_logger = {
+                'unknown': 'unknown'
+            }
+        else:
+            project_page_num_offset_for_logger = project_page_num_offset
+
         LOGGER.info('Checking state {}: {} and {}: {}'.format(
             '.'.join(updated_bookmark), project_updated_bookmark,
-            '.'.join(project_page_num_offset), project_page_num_offset
+            '.'.join(project_page_num_offset_for_logger), project_page_num_offset
         ))
 
         if not project_page_num_offset and not project_updated_bookmark:

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -180,13 +180,13 @@ def sync_sub_streams(page, issue_changelog_updated, changelog_map=None):
                 changelog_items = []
                 for item in changelog['items']:
                     if 'fieldId' in item and should_exclude_field(item['fieldId'], item['field']):
-                        if item['from'] is not None and item['from'] != '':
+                        if 'from' in item and item['from'] is not None and item['from'] != '':
                             item['from'] = '<REDACTED>'
-                        if item['fromString'] is not None and item['fromString'] != '':
+                        if 'fromString' in item and item['fromString'] is not None and item['fromString'] != '':
                             item['fromString'] = '<REDACTED>'
-                        if item['to'] is not None and item['to'] != '':
+                        if 'to' in item and item['to'] is not None and item['to'] != '':
                             item['to'] = '<REDACTED>'
-                        if item['toString'] is not None and item['toString'] != '':
+                        if 'toString' in item and item['toString'] is not None and item['toString'] != '':
                             item['toString'] = '<REDACTED>'
                         
                     changelog_items.append(item)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -3,6 +3,7 @@ import functools
 import json
 import threading
 import pytz
+import psutil
 import requests
 import singer
 import datetime
@@ -17,10 +18,28 @@ from minware_singer_utils import SecureLogger
 
 LOGGER = SecureLogger(singer.get_logger())
 
+def log_memory(message, *args):
+    """
+    Log current process memory usage with a custom message.
+    Returns the current memory in MB for further processing if needed.
+    """
+    current_process = psutil.Process()
+    current_memory_mb = current_process.memory_info().rss / 1024 / 1024
+    
+    # Format message with args if provided
+    if args:
+        formatted_message = message % args
+    else:
+        formatted_message = message
+    
+    LOGGER.info(f"{formatted_message}: {current_memory_mb:.1f} MB")
+    return current_memory_mb
+
 def partition_list(lst, batch_size):
     """Partition a list into batches of specified size."""
     for i in range(0, len(lst), batch_size):
         yield lst[i:i + batch_size]
+
 
 def bulk_fetch_issues_parallel(client, tap_stream_id, issue_ids, fields=None, max_workers=10):
     """
@@ -45,6 +64,9 @@ def bulk_fetch_issues_parallel(client, tap_stream_id, issue_ids, fields=None, ma
     def fetch_batch(batch):
         return client.bulk_fetch_issues(tap_stream_id, batch, fields)
     
+    # Monitor memory before parallel fetching
+    initial_memory_mb = log_memory("Memory before parallel fetch")
+    
     # Use ThreadPoolExecutor for parallel fetching
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         futures = [executor.submit(fetch_batch, batch) for batch in batches]
@@ -53,12 +75,16 @@ def bulk_fetch_issues_parallel(client, tap_stream_id, issue_ids, fields=None, ma
             try:
                 issues = future.result()
                 all_issues.extend(issues)
-                LOGGER.info(f"Fetched batch of {len(issues)} issues")
+                # Monitor memory after each parallel batch fetch
+                log_memory(f"Fetched batch of {len(issues)} issues")
             except Exception as exc:
                 LOGGER.error(f"Batch fetch failed: {exc}")
                 raise exc
     
-    LOGGER.info(f"Completed parallel fetch: {len(all_issues)} total issues")
+    # Monitor memory after all parallel fetching completes
+    final_memory_mb = log_memory(f"Completed parallel fetch: {len(all_issues)} total issues")
+    memory_growth = final_memory_mb - initial_memory_mb
+    LOGGER.info(f"Memory growth during parallel fetch: {memory_growth:.1f} MB")
     return all_issues
 
 def bulk_fetch_changelogs_for_issues(client, tap_stream_id, issue_ids):
@@ -73,12 +99,17 @@ def bulk_fetch_changelogs_for_issues(client, tap_stream_id, issue_ids):
     if not issue_ids:
         return {}
     
+    # Monitor memory before changelog fetching
+    initial_memory_mb = log_memory("Memory before changelog fetch")
+    
     changelog_map = {}
+    total_changelogs = 0
     
     # Process in batches of 1000 (API limit)
-    for batch in partition_list(issue_ids, 1000):
-        LOGGER.info(f"Bulk fetching changelogs for {len(batch)} issues")
+    for batch_index, batch in enumerate(partition_list(issue_ids, 1000)):
+        LOGGER.info(f"Bulk fetching changelogs for batch {batch_index} ({len(batch)} issues)")
         
+        batch_changelogs = 0
         for changelog_page in client.bulk_fetch_changelogs(tap_stream_id, batch):
             for changelog in changelog_page:
                 issue_id = changelog.get("issueId")
@@ -88,10 +119,18 @@ def bulk_fetch_changelogs_for_issues(client, tap_stream_id, issue_ids):
                     if issue_id_str not in changelog_map:
                         changelog_map[issue_id_str] = []
                     changelog_map[issue_id_str].append(changelog)
+                    batch_changelogs += 1
                 else:
                     LOGGER.warning(f"Changelog missing issueId: {changelog.keys()}")
+        
+        total_changelogs += batch_changelogs
+        # Monitor memory after each batch
+        log_memory(f"After changelog batch {batch_index}: {batch_changelogs} changelogs fetched")
     
-    LOGGER.info(f"Bulk fetched changelogs for {len(changelog_map)} issues total")
+    # Final memory report
+    final_memory_mb = log_memory(f"Bulk fetched {total_changelogs} changelogs for {len(changelog_map)} issues")
+    memory_growth = final_memory_mb - initial_memory_mb
+    LOGGER.info(f"Memory growth during changelog fetch: {memory_growth:.1f} MB")
     
     return changelog_map
 
@@ -195,6 +234,11 @@ def sync_sub_streams(page, issue_changelog_updated, changelog_map=None):
             CHANGELOGS.write_page(
                 [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
             )
+            
+            # Monitor memory after processing large changelog sets
+            if len(changelogs_to_write) > 100:
+                log_memory("Memory after %d changelogs for issue %s", 
+                          len(changelogs_to_write), issue["id"])
 
         # Note: Transitions are not available via expand in API v3
         # We will need to fetch them separately if they are needed
@@ -506,6 +550,9 @@ class Issues(Stream):
             project_key_or_id = self.ALL_PROJECTS_BOOKMARK_KEY
 
         LOGGER.info('Begin syncing issues for project {}'.format(project_key_or_id))
+        
+        # Monitor memory at start of project sync
+        log_memory("Starting memory for project %s", project_key_or_id)
 
         # build projects filter from config, if any
         projectsJql = "" if project_key_or_id == self.ALL_PROJECTS_BOOKMARK_KEY \
@@ -540,103 +587,151 @@ class Issues(Stream):
         # Two-phase approach for optimal performance
         jql = "{} updated >= '{}' order by updated asc".format(projectsJql, start_date).strip()
         
-        # Phase 1: Fetch all issue IDs returned by the JQL query (fast, up to 5000 per request)
-        LOGGER.info("Phase 1: Fetching all issue IDs returned by the JQL query for project %s", project_key_or_id)
+        # Phase 1: Get ALL issue IDs in chronological order (fast, guaranteed ordering)
+        # JQL "ORDER BY updated ASC" ensures IDs are returned in chronological sequence
+        LOGGER.info("Phase 1: Fetching all issue IDs in chronological order for project %s", project_key_or_id)
         id_pager = EnhancedSearchPaginator(Context.client, max_results=5000, ids_only=True)
-        all_issue_ids = []
+        all_issue_ids = []  # This will contain IDs in chronological order by 'updated' timestamp
         
-        for page in id_pager.pages(self.tap_stream_id, jql):
-            issue_ids = [issue["id"] for issue in page]
-            all_issue_ids.extend(issue_ids)
+        for id_page in id_pager.pages(self.tap_stream_id, jql):
+            issue_ids = [issue["id"] for issue in id_page]
+            all_issue_ids.extend(issue_ids)  # Preserves chronological order from JQL
             LOGGER.info("Collected %d issue IDs (total: %d)", len(issue_ids), len(all_issue_ids))
         
-        LOGGER.info("Phase 1 complete: Found %d total issues for project %s", len(all_issue_ids), project_key_or_id)
+        LOGGER.info("Phase 1 complete: Found %d total issues in chronological order for project %s", len(all_issue_ids), project_key_or_id)
         
         if not all_issue_ids:
             LOGGER.info("No issues found for project %s", project_key_or_id)
             return
         
-        # Phase 2: Bulk fetch issue details in parallel
-        LOGGER.info("Phase 2: Bulk fetching issue details for project %s", project_key_or_id)
-        fields = ["*all"]
-        all_issues = bulk_fetch_issues_parallel(Context.client, self.tap_stream_id, all_issue_ids, fields)
+        # Phase 2: Process ordered IDs in batches using bulk fetch (preserves order from Phase 1)
+        LOGGER.info("Phase 2: Processing %d ordered issue IDs in batches", len(all_issue_ids))
+        batch_size = 5000  # Bulk fetch batch size
+        sub_batch_size = 100  # Writing sub-batch size
+        max_updated_seen = None
         
-        # Phase 3: Bulk fetch changelogs if needed
-        changelog_map = None
-        if Context.is_selected(CHANGELOGS.tap_stream_id):
-            LOGGER.info("Phase 3: Bulk fetching changelogs for project %s", project_key_or_id)
-            changelog_map = bulk_fetch_changelogs_for_issues(Context.client, CHANGELOGS.tap_stream_id, all_issue_ids)
-            LOGGER.info("Found changelogs for %s issues", len(changelog_map) if changelog_map else 0)
-        else:
-            LOGGER.info("Changelogs stream is NOT selected - skipping changelog fetch")
+        for batch_start in range(0, len(all_issue_ids), batch_size):
+            batch_end = min(batch_start + batch_size, len(all_issue_ids))
+            batch_ids = all_issue_ids[batch_start:batch_end]  # Maintains JQL order!
+            
+            batch_index = batch_start // batch_size
+            LOGGER.info("Processing batch %d: issues %d-%d (%d issues) for project %s", 
+                       batch_index, batch_start, batch_end-1, len(batch_ids), project_key_or_id)
+            
+            # Monitor memory at start of batch
+            log_memory("Memory before processing batch %d for project %s", batch_index, project_key_or_id)
+            
+            # Bulk fetch issues for this batch (parallel execution scrambles the order)
+            batch_issues = bulk_fetch_issues_parallel(Context.client, self.tap_stream_id, batch_ids, ["*all"])
+            
+            # CRITICAL: Restore chronological order that was scrambled by parallel bulk fetch
+            # - batch_ids contains IDs in JQL chronological order (ORDER BY updated ASC)
+            # - batch_issues contains the same issues but in random order due to parallel execution
+            # - We use issue IDs as lookup keys to rebuild the chronological sequence
+            LOGGER.info("Restoring chronological order for %d bulk-fetched issues", len(batch_issues))
+            id_to_issue = {issue["id"]: issue for issue in batch_issues}  # Create lookup map
+            ordered_batch_issues = []
+            for issue_id in batch_ids:  # Iterate in original JQL chronological order
+                if issue_id in id_to_issue:
+                    # Add issue back in chronological position (not sorted by ID, but by updated timestamp)
+                    ordered_batch_issues.append(id_to_issue[issue_id])
+                else:
+                    LOGGER.warning("Issue ID %s not found in bulk fetch results", issue_id)
+            
+            LOGGER.info("Batch %d: Restored chronological order for %d issues", batch_index, len(ordered_batch_issues))
+            
+            # Fetch changelogs for this batch if needed
+            changelog_map = None
+            if Context.is_selected(CHANGELOGS.tap_stream_id):
+                LOGGER.info("Fetching changelogs for batch %d (%d issues)", batch_index, len(batch_ids))
+                changelog_map = bulk_fetch_changelogs_for_issues(Context.client, CHANGELOGS.tap_stream_id, batch_ids)
+            
+            # Process batch in smaller sub-batches for writing (maintaining JQL order)
+            for sub_batch_index, sub_batch_start in enumerate(range(0, len(ordered_batch_issues), sub_batch_size)):
+                sub_batch_end = min(sub_batch_start + sub_batch_size, len(ordered_batch_issues))
+                issue_batch = ordered_batch_issues[sub_batch_start:sub_batch_end]
+                
+                LOGGER.info("Processing sub-batch %d (%d-%d) with %d issues from batch %d", 
+                           sub_batch_index, sub_batch_start, sub_batch_end-1, len(issue_batch), batch_index)
+                
+                # sync comments and changelogs for each issue
+                sync_sub_streams(issue_batch, issue_changelogs_updated, changelog_map)
+                
+                for issue in issue_batch:
+                    issue['fields'].pop('worklog', None)
+                    # The JSON schema for the search endpoint indicates an "operations"
+                    # field can be present. This field is self-referential, making it
+                    # difficult to deal with - we would have to flatten the operations
+                    # and just have each operation include the IDs of other operations
+                    # it references. However the operations field has something to do
+                    # with the UI within Jira - I believe the operations are parts of
+                    # the "menu" bar for each issue. This is of questionable utility,
+                    # so we decided to just strip the field out for now.
+                    issue['fields'].pop('operations', None)
+
+                    # Track maximum updated timestamp seen - in JQL order, this will be monotonically increasing
+                    issue_updated = utils.strptime_to_utc(issue["fields"]["updated"])
+                    if max_updated_seen is None or issue_updated > max_updated_seen:
+                        max_updated_seen = issue_updated
+
+                    # Rename all of the custom fields
+                    # filter excluded fields
+                    for k in list(issue['fields'].keys()):
+                        if k[:len('customfield_')] == 'customfield_':
+                            val = issue['fields'][k]
+                            del issue['fields'][k]
+                            issue['fields'][fieldNames[k]] = val
+
+                        if fieldNames[k] in issue['fields'] and should_exclude_field(k, fieldNames[k]):
+                            LOGGER.debug('Excluding field {} - {}'.format(k, fieldNames[k]))
+                            issue['fields'][fieldNames[k]] = '<REDACTED>'
+
+                    # Now, go through and separate fields we don't recognize into "_custom"
+                    customFields = {}
+                    for k in list(issue['fields'].keys()):
+                        # If we don't know about this field, then put it in a "_custom" object for
+                        # outputting as a single JSON
+                        if not k in knownFields:
+                            val = issue['fields'][k]
+                            # Don't include null values, which just waste a bunch of space
+                            if val != None:
+                                customFields[k] = val
+                            del issue['fields'][k]
+                    issue['fields']['_custom'] = json.dumps(customFields)
+                    
+                LOGGER.info("Writing sub-batch %d with %d issues from batch %d...", sub_batch_index, len(issue_batch), batch_index)
+                with self.write_lock:
+                    self.write_page(issue_batch)
+                    # Update bookmark with maximum updated timestamp (safe since issues are JQL-ordered)
+                    if max_updated_seen:
+                        Context.set_bookmark(updated_bookmark, max_updated_seen)
+                    Context.set_bookmark(issue_changelogs_updated_bookmark_path, issue_changelogs_sync_time)
+                    singer.write_state(Context.state)
+                
+                # Monitor memory usage after processing each batch
+                log_memory("Memory after sub-batch %d from batch %d", sub_batch_index, batch_index)
+                
+                LOGGER.info("Finished writing sub-batch %d from batch %d", sub_batch_index, batch_index)
+            
+            # Batch complete - clear variables to help with memory cleanup
+            log_memory("Memory at end of batch %d (should decrease on next batch)", batch_index)
+            del ordered_batch_issues
+            if changelog_map:
+                del changelog_map
         
-        # Process issues in batches for progress tracking and state emission
-        LOGGER.info("Processing %d issues in batches for project %s", len(all_issues), project_key_or_id)
-        batch_size = 100
-        
-        for batch_index, batch_start in enumerate(range(0, len(all_issues), batch_size)):
-            batch_end = min(batch_start + batch_size, len(all_issues))
-            issue_batch = all_issues[batch_start:batch_end]
-            
-            LOGGER.info("Processing batch %d (%d-%d) with %d issues for project %s", 
-                       batch_index, batch_start, batch_end-1, len(issue_batch), project_key_or_id)
-            
-            # sync comments and changelogs for each issue
-            sync_sub_streams(issue_batch, issue_changelogs_updated, changelog_map)
-            
-            for issue in issue_batch:
-                issue['fields'].pop('worklog', None)
-                # The JSON schema for the search endpoint indicates an "operations"
-                # field can be present. This field is self-referential, making it
-                # difficult to deal with - we would have to flatten the operations
-                # and just have each operation include the IDs of other operations
-                # it references. However the operations field has something to do
-                # with the UI within Jira - I believe the operations are parts of
-                # the "menu" bar for each issue. This is of questionable utility,
-                # so we decided to just strip the field out for now.
-                issue['fields'].pop('operations', None)
-
-                # Rename all of the custom fields
-                # filter excluded fields
-                for k in list(issue['fields'].keys()):
-                    if k[:len('customfield_')] == 'customfield_':
-                        val = issue['fields'][k]
-                        del issue['fields'][k]
-                        issue['fields'][fieldNames[k]] = val
-
-                    if fieldNames[k] in issue['fields'] and should_exclude_field(k, fieldNames[k]):
-                        LOGGER.debug('Excluding field {} - {}'.format(k, fieldNames[k]))
-                        issue['fields'][fieldNames[k]] = '<REDACTED>'
-
-                # Now, go through and separate fields we don't recognize into "_custom"
-                customFields = {}
-                for k in list(issue['fields'].keys()):
-                    # If we don't know about this field, then put it in a "_custom" object for
-                    # outputting as a single JSON
-                    if not k in knownFields:
-                        val = issue['fields'][k]
-                        # Don't include null values, which just waste a bunch of space
-                        if val != None:
-                            customFields[k] = val
-                        del issue['fields'][k]
-                issue['fields']['_custom'] = json.dumps(customFields)
-
-            # Grab last_updated before transform in write_page
-            last_updated = utils.strptime_to_utc(issue_batch[-1]["fields"]["updated"])
-            LOGGER.info("Writing batch %d with %d issues for project %s...", batch_index, len(issue_batch), project_key_or_id)
-            with self.write_lock:
-                self.write_page(issue_batch)
-                singer.write_state(Context.state)
-            
-            LOGGER.info("Finished writing batch %d for project %s", batch_index, project_key_or_id)
-        
-        # After the loop completes
+        # All batches complete - final state update
+        LOGGER.info("All ordered batches complete for project %s", project_key_or_id)
         with self.write_lock:
-            # Remove page number bookmarking since enhanced API uses tokens
-            Context.set_bookmark(updated_bookmark, last_updated)
+            # Final bookmark update with maximum updated timestamp seen
+            if max_updated_seen:
+                Context.set_bookmark(updated_bookmark, max_updated_seen)
+                LOGGER.info("Final bookmark set to maximum updated timestamp: %s", max_updated_seen)
             Context.set_bookmark(issue_changelogs_updated_bookmark_path, issue_changelogs_sync_time)
             singer.write_state(Context.state)
 
+        # Final memory report for this project
+        log_memory("Final memory after syncing project %s", project_key_or_id)
+        
         LOGGER.info('Done syncing project %s', project_key_or_id)
 
 

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -13,6 +13,9 @@ from .context import Context
 from itertools import chain
 from concurrent.futures import ThreadPoolExecutor
 
+from minware_singer_utils import SecureLogger
+
+LOGGER = SecureLogger(singer.get_logger())
 
 def raise_if_bookmark_cannot_advance(worklogs):
     # Worklogs can only be queried with a `since` timestamp and
@@ -129,9 +132,6 @@ def advance_bookmark(worklogs):
     new_last_updated = max(utils.strptime_to_utc(w["updated"])
                            for w in worklogs)
     return new_last_updated
-
-
-LOGGER = singer.get_logger()
 
 
 class Stream():

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -337,24 +337,43 @@ class Issues(Stream):
         projectsToSync = Context.get_projects()
         if len(projectsToSync) == 0:
             with Timer('issues_sync', { 'project': self.ALL_PROJECTS_BOOKMARK_KEY }):
-                self.sync_project(fieldNames, knownFields)
+                result = self._sync_project_with_error_handling(fieldNames, knownFields, None)
+                if result["status"] != "success":
+                    LOGGER.warning(f"Project sync for ALL_PROJECTS completed with status: {result['status']}")
         else:
+            # Process projects in parallel using ThreadPoolExecutor
             with ThreadPoolExecutor(max_workers=6) as executor:
                 func_call_futures = []
                 for project_key_or_id in projectsToSync:
                     ctx = contextvars.copy_context()
-                    func_call = functools.partial(ctx.run, self.sync_project, fieldNames, knownFields, project_key_or_id)
+                    func_call = functools.partial(ctx.run, self._sync_project_with_error_handling, fieldNames, knownFields, project_key_or_id)
                     func_call_futures.append(executor.submit(func_call))
-
-                # bubble up any exceptions discovered while syncing a project
-                try:
-                    for future in as_completed(func_call_futures):
-                        future.result()
-                except Exception as ex:
-                    LOGGER.error(
-                        "Issues.sync encountered an error in a thread: %s", ex
-                    )
-                    raise ex
+                
+                # Process results from all threads
+                success_count = 0
+                error_count = 0
+                failed_projects = []
+                
+                for future in as_completed(func_call_futures):
+                    try:
+                        result = future.result()
+                        if result["status"] == "success":
+                            success_count += 1
+                        else:
+                            # This should only happen for handled 400 errors
+                            error_count += 1
+                            failed_projects.append(result["project"])
+                    except Exception as exc:
+                        # This will happen for any re-raised exceptions from _sync_project_with_error_handling
+                        # We need to re-raise to ensure the tap fails properly
+                        LOGGER.error(f"A project sync failed with an unhandled error: {exc}")
+                        raise exc
+            
+            LOGGER.info(f"Completed processing {len(projectsToSync)} projects:")
+            LOGGER.info(f"  - {success_count} succeeded")
+            if error_count > 0:
+                LOGGER.warning(f"  - {error_count} failed with handled errors (these projects were skipped)")
+                LOGGER.warning(f"Failed projects: {', '.join(failed_projects)}")
 
         self.delete_old_state()
 
@@ -389,6 +408,31 @@ class Issues(Stream):
                 LOGGER.info('Updated being copied from previous state format')
                 Context.set_bookmark(updated_bookmark, non_project_updated_bookmark)
                 Context.set_bookmark(page_num_offset, 0)
+
+    def _sync_project_with_error_handling(self, fieldNames, knownFields, project_key_or_id):
+        """Wrapper method to handle errors during project sync in threads"""
+        try:
+            LOGGER.info(f"Starting sync for project: {project_key_or_id}")
+            with Timer('issues_sync', { 'project': project_key_or_id }):
+                self.sync_project(fieldNames, knownFields, project_key_or_id)
+            LOGGER.info(f"Successfully completed sync for project: {project_key_or_id}")
+            return {"status": "success", "project": project_key_or_id}
+        except requests.exceptions.HTTPError as http_err:
+            # Handle specific 400 errors at the project level
+            if http_err.response.status_code == 400 and '/rest/api/2/search' in http_err.response.url:
+                LOGGER.warning(f"Project {project_key_or_id}: Encountered a handled 400 error with Jira search API")
+                LOGGER.warning(f"URL: {http_err.response.url}")
+                LOGGER.warning(f"Response body: {http_err.response.text}")
+                LOGGER.warning(f"This error is being handled as non-fatal. Sync will continue with other projects.")
+                return {"status": "error", "project": project_key_or_id, "error_type": "handled_400"}
+            else:
+                # Re-raise other HTTP errors
+                LOGGER.error(f"Project {project_key_or_id}: Encountered an HTTP error: {http_err}")
+                raise http_err
+        except Exception as exc:
+            # Re-raise other exceptions
+            LOGGER.error(f"Project {project_key_or_id}: Encountered an error: {exc}")
+            raise exc
 
     def sync_project(self, fieldNames, knownFields, project_key_or_id = None):
         if project_key_or_id is None:

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -8,7 +8,7 @@ import singer
 import datetime
 
 from singer import metrics, utils, metadata, Transformer, Timer
-from .http import Paginator
+from .http import Paginator, EnhancedSearchPaginator
 from .context import Context
 from itertools import chain
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -16,6 +16,84 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from minware_singer_utils import SecureLogger
 
 LOGGER = SecureLogger(singer.get_logger())
+
+def partition_list(lst, batch_size):
+    """Partition a list into batches of specified size."""
+    for i in range(0, len(lst), batch_size):
+        yield lst[i:i + batch_size]
+
+def bulk_fetch_issues_parallel(client, tap_stream_id, issue_ids, fields=None, max_workers=10):
+    """
+    Fetch issue details in parallel using bulk fetch API.
+    
+    :param client: Jira client instance
+    :param tap_stream_id: Stream ID for metrics
+    :param issue_ids: List of issue IDs to fetch
+    :param fields: List of fields to return
+    :param max_workers: Maximum number of parallel workers
+    :return: List of all fetched issues
+    """
+    if not issue_ids:
+        return []
+    
+    # Partition into batches of 100 (max for bulk fetch API)
+    batches = list(partition_list(issue_ids, 100))
+    LOGGER.info(f"Fetching {len(issue_ids)} issues in {len(batches)} parallel batches")
+    
+    all_issues = []
+    
+    def fetch_batch(batch):
+        return client.bulk_fetch_issues(tap_stream_id, batch, fields)
+    
+    # Use ThreadPoolExecutor for parallel fetching
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(fetch_batch, batch) for batch in batches]
+        
+        for future in as_completed(futures):
+            try:
+                issues = future.result()
+                all_issues.extend(issues)
+                LOGGER.info(f"Fetched batch of {len(issues)} issues")
+            except Exception as exc:
+                LOGGER.error(f"Batch fetch failed: {exc}")
+                raise exc
+    
+    LOGGER.info(f"Completed parallel fetch: {len(all_issues)} total issues")
+    return all_issues
+
+def bulk_fetch_changelogs_for_issues(client, tap_stream_id, issue_ids):
+    """
+    Bulk fetch changelogs for a list of issues using the bulk changelog API.
+    
+    :param client: Jira client instance
+    :param tap_stream_id: Stream ID for metrics
+    :param issue_ids: List of issue IDs to fetch changelogs for
+    :return: Dictionary mapping issue_id to list of changelogs
+    """
+    if not issue_ids:
+        return {}
+    
+    changelog_map = {}
+    
+    # Process in batches of 1000 (API limit)
+    for batch in partition_list(issue_ids, 1000):
+        LOGGER.info(f"Bulk fetching changelogs for {len(batch)} issues")
+        
+        for changelog_page in client.bulk_fetch_changelogs(tap_stream_id, batch):
+            for changelog in changelog_page:
+                issue_id = changelog.get("issueId")
+                if issue_id:
+                    # Ensure consistent string type for issue ID
+                    issue_id_str = str(issue_id)
+                    if issue_id_str not in changelog_map:
+                        changelog_map[issue_id_str] = []
+                    changelog_map[issue_id_str].append(changelog)
+                else:
+                    LOGGER.warning(f"Changelog missing issueId: {changelog.keys()}")
+    
+    LOGGER.info(f"Bulk fetched changelogs for {len(changelog_map)} issues total")
+    
+    return changelog_map
 
 def raise_if_bookmark_cannot_advance(worklogs):
     # Worklogs can only be queried with a `since` timestamp and
@@ -72,7 +150,7 @@ def should_exclude_field(field_id, field_name):
     
     return False
 
-def sync_sub_streams(page, issue_changelog_updated):
+def sync_sub_streams(page, issue_changelog_updated, changelog_map=None):
     for issue in page:
         comments = issue["fields"].pop("comment")["comments"]
         if comments and Context.is_selected(ISSUE_COMMENTS.tap_stream_id):
@@ -81,23 +159,21 @@ def sync_sub_streams(page, issue_changelog_updated):
             ISSUE_COMMENTS.write_page(comments)
 
         if Context.is_selected(CHANGELOGS.tap_stream_id):
-            changelog_response = issue.pop("changelog")
-            changelogs = changelog_response["histories"]
             changelogs_to_write = []
-
-            # when expanding changelogs for an issue, jira returns 100
-            if changelog_response['maxResults'] >= changelog_response['total']:
-                for changelog in changelogs:
-                    changelogs_to_write.append(changelog)
+            issue_id = str(issue["id"])  # Ensure consistent string type
+            
+            # Use bulk-fetched changelog data
+            if changelog_map is not None and issue_id in changelog_map:
+                changelogs_to_write = changelog_map[issue_id]
+                # Ensure issueId is set on each changelog
+                for changelog in changelogs_to_write:
+                    changelog["issueId"] = issue_id
+            elif changelog_map is not None:
+                # No changelogs found for this issue (empty list)
+                changelogs_to_write = []
             else:
-                pager = Paginator(Context.client)
-                for page in pager.pages(
-                    CHANGELOGS.tap_stream_id,
-                    "GET",
-                    "/rest/api/2/issue/{}/changelog".format(issue["id"])
-                ):
-                    for changelog in page:
-                        changelogs_to_write.append(changelog)
+                # This should not happen since we always bulk fetch if changelogs are selected
+                raise Exception(f"Changelog map is None but changelogs are selected for issue {issue_id}")
 
 
             for changelog in changelogs_to_write:
@@ -120,11 +196,10 @@ def sync_sub_streams(page, issue_changelog_updated):
                 [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
             )
 
-        transitions = issue.pop("transitions")
-        if transitions and Context.is_selected(ISSUE_TRANSITIONS.tap_stream_id):
-            for transition in transitions:
-                transition["issueId"] = issue["id"]
-            ISSUE_TRANSITIONS.write_page(transitions)
+        # Note: Transitions are not available via expand in API v3
+        # We will need to fetch them separately if they are needed
+        # These are just the transitions that are available for the issue
+        # And we don't need them for the current use case
 
 
 def advance_bookmark(worklogs):
@@ -341,33 +416,25 @@ class Issues(Stream):
                 if result["status"] != "success":
                     LOGGER.warning(f"Project sync for ALL_PROJECTS completed with status: {result['status']}")
         else:
-            # Process projects in parallel using ThreadPoolExecutor
-            with ThreadPoolExecutor(max_workers=6) as executor:
-                func_call_futures = []
-                for project_key_or_id in projectsToSync:
-                    ctx = contextvars.copy_context()
-                    func_call = functools.partial(ctx.run, self._sync_project_with_error_handling, fieldNames, knownFields, project_key_or_id)
-                    func_call_futures.append(executor.submit(func_call))
-                
-                # Process results from all threads
-                success_count = 0
-                error_count = 0
-                failed_projects = []
-                
-                for future in as_completed(func_call_futures):
-                    try:
-                        result = future.result()
-                        if result["status"] == "success":
-                            success_count += 1
-                        else:
-                            # This should only happen for handled 400 errors
-                            error_count += 1
-                            failed_projects.append(result["project"])
-                    except Exception as exc:
-                        # This will happen for any re-raised exceptions from _sync_project_with_error_handling
-                        # We need to re-raise to ensure the tap fails properly
-                        LOGGER.error(f"A project sync failed with an unhandled error: {exc}")
-                        raise exc
+            # Process projects sequentially to avoid rate limit quota bursts and connection pool exhaustion
+            success_count = 0
+            error_count = 0
+            failed_projects = []
+            
+            for project_key_or_id in projectsToSync:
+                try:
+                    result = self._sync_project_with_error_handling(fieldNames, knownFields, project_key_or_id)
+                    if result["status"] == "success":
+                        success_count += 1
+                    else:
+                        # This should only happen for handled 400 errors
+                        error_count += 1
+                        failed_projects.append(result["project"])
+                except Exception as exc:
+                    # This will happen for any re-raised exceptions from _sync_project_with_error_handling
+                    # We need to re-raise to ensure the tap fails properly
+                    LOGGER.error(f"A project sync failed with an unhandled error: {exc}")
+                    raise exc
             
             LOGGER.info(f"Completed processing {len(projectsToSync)} projects:")
             LOGGER.info(f"  - {success_count} succeeded")
@@ -419,7 +486,7 @@ class Issues(Stream):
             return {"status": "success", "project": project_key_or_id}
         except requests.exceptions.HTTPError as http_err:
             # Handle specific 400 errors at the project level
-            if http_err.response.status_code == 400 and '/rest/api/2/search' in http_err.response.url:
+            if http_err.response.status_code == 400 and '/rest/api/3/search/jql' in http_err.response.url:
                 LOGGER.warning(f"Project {project_key_or_id}: Encountered a handled 400 error with Jira search API")
                 LOGGER.warning(f"URL: {http_err.response.url}")
                 LOGGER.warning(f"Response body: {http_err.response.text}")
@@ -470,28 +537,54 @@ class Issues(Stream):
 
         LOGGER.info('using updated >= \'{}\''.format(start_date))
 
-        # Now fetch all the actual issues, translating custom fields
+        # Two-phase approach for optimal performance
         jql = "{} updated >= '{}' order by updated asc".format(projectsJql, start_date).strip()
-        params = {"fields": "*all",
-                  "expand": "changelog,transitions",
-                  "validateQuery": "strict",
-                  "maxResults": 100,
-                  "jql": jql}
-        page_num = Context.bookmark(page_num_offset) or 0
-        pager = Paginator(Context.client, items_key="issues", page_num=page_num)
-
-        page_index = 0
-        for page in pager.pages(self.tap_stream_id,
-                                "GET", "/rest/api/2/search",
-                                params=params):
-
-            LOGGER.info(
-                "Fetched page %d with %d issues for project %s",
-                page_index, len(page), project_key_or_id
-            )
+        
+        # Phase 1: Fetch all issue IDs returned by the JQL query (fast, up to 5000 per request)
+        LOGGER.info("Phase 1: Fetching all issue IDs returned by the JQL query for project %s", project_key_or_id)
+        id_pager = EnhancedSearchPaginator(Context.client, max_results=5000, ids_only=True)
+        all_issue_ids = []
+        
+        for page in id_pager.pages(self.tap_stream_id, jql):
+            issue_ids = [issue["id"] for issue in page]
+            all_issue_ids.extend(issue_ids)
+            LOGGER.info("Collected %d issue IDs (total: %d)", len(issue_ids), len(all_issue_ids))
+        
+        LOGGER.info("Phase 1 complete: Found %d total issues for project %s", len(all_issue_ids), project_key_or_id)
+        
+        if not all_issue_ids:
+            LOGGER.info("No issues found for project %s", project_key_or_id)
+            return
+        
+        # Phase 2: Bulk fetch issue details in parallel
+        LOGGER.info("Phase 2: Bulk fetching issue details for project %s", project_key_or_id)
+        fields = ["*all"]
+        all_issues = bulk_fetch_issues_parallel(Context.client, self.tap_stream_id, all_issue_ids, fields)
+        
+        # Phase 3: Bulk fetch changelogs if needed
+        changelog_map = None
+        if Context.is_selected(CHANGELOGS.tap_stream_id):
+            LOGGER.info("Phase 3: Bulk fetching changelogs for project %s", project_key_or_id)
+            changelog_map = bulk_fetch_changelogs_for_issues(Context.client, CHANGELOGS.tap_stream_id, all_issue_ids)
+            LOGGER.info("Found changelogs for %s issues", len(changelog_map) if changelog_map else 0)
+        else:
+            LOGGER.info("Changelogs stream is NOT selected - skipping changelog fetch")
+        
+        # Process issues in batches for progress tracking and state emission
+        LOGGER.info("Processing %d issues in batches for project %s", len(all_issues), project_key_or_id)
+        batch_size = 100
+        
+        for batch_index, batch_start in enumerate(range(0, len(all_issues), batch_size)):
+            batch_end = min(batch_start + batch_size, len(all_issues))
+            issue_batch = all_issues[batch_start:batch_end]
+            
+            LOGGER.info("Processing batch %d (%d-%d) with %d issues for project %s", 
+                       batch_index, batch_start, batch_end-1, len(issue_batch), project_key_or_id)
+            
             # sync comments and changelogs for each issue
-            sync_sub_streams(page, issue_changelogs_updated)
-            for issue in page:
+            sync_sub_streams(issue_batch, issue_changelogs_updated, changelog_map)
+            
+            for issue in issue_batch:
                 issue['fields'].pop('worklog', None)
                 # The JSON schema for the search endpoint indicates an "operations"
                 # field can be present. This field is self-referential, making it
@@ -528,22 +621,18 @@ class Issues(Stream):
                         del issue['fields'][k]
                 issue['fields']['_custom'] = json.dumps(customFields)
 
-
             # Grab last_updated before transform in write_page
-            last_updated = utils.strptime_to_utc(page[-1]["fields"]["updated"])
-            LOGGER.info("Writing issues for page %d, project %s...", page_index, project_key_or_id)
+            last_updated = utils.strptime_to_utc(issue_batch[-1]["fields"]["updated"])
+            LOGGER.info("Writing batch %d with %d issues for project %s...", batch_index, len(issue_batch), project_key_or_id)
             with self.write_lock:
-                self.write_page(page)
-
-                Context.set_bookmark(page_num_offset, pager.next_page_num)
+                self.write_page(issue_batch)
                 singer.write_state(Context.state)
             
-            LOGGER.info("Finished writing issues for page %d, project %s", page_index, project_key_or_id)
-            page_index += 1
+            LOGGER.info("Finished writing batch %d for project %s", batch_index, project_key_or_id)
         
         # After the loop completes
         with self.write_lock:
-            Context.set_bookmark(page_num_offset, None)
+            # Remove page number bookmarking since enhanced API uses tokens
             Context.set_bookmark(updated_bookmark, last_updated)
             Context.set_bookmark(issue_changelogs_updated_bookmark_path, issue_changelogs_sync_time)
             singer.write_state(Context.state)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -11,7 +11,7 @@ from singer import metrics, utils, metadata, Transformer, Timer
 from .http import Paginator
 from .context import Context
 from itertools import chain
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from minware_singer_utils import SecureLogger
 
@@ -346,12 +346,15 @@ class Issues(Stream):
                     func_call = functools.partial(ctx.run, self.sync_project, fieldNames, knownFields, project_key_or_id)
                     func_call_futures.append(executor.submit(func_call))
 
-                ## bubble up any exceptions discovered while syncing a project
+                # bubble up any exceptions discovered while syncing a project
                 try:
-                    for func_call_future in func_call_futures:
-                        func_call_future.result()
+                    for future in as_completed(func_call_futures):
+                        future.result()
                 except Exception as ex:
-                    LOGGER.exception(ex)
+                    LOGGER.error(
+                        "Issues.sync encountered an error in a thread: %s", ex
+                    )
+                    raise ex
 
         self.delete_old_state()
 
@@ -381,7 +384,7 @@ class Issues(Stream):
         if project_key_or_id is None:
             project_key_or_id = self.ALL_PROJECTS_BOOKMARK_KEY
 
-        LOGGER.info('syncing issues for project {}'.format(project_key_or_id))
+        LOGGER.info('Begin syncing issues for project {}'.format(project_key_or_id))
 
         # build projects filter from config, if any
         projectsJql = "" if project_key_or_id == self.ALL_PROJECTS_BOOKMARK_KEY \
@@ -422,9 +425,16 @@ class Issues(Stream):
                   "jql": jql}
         page_num = Context.bookmark(page_num_offset) or 0
         pager = Paginator(Context.client, items_key="issues", page_num=page_num)
+
+        page_index = 0
         for page in pager.pages(self.tap_stream_id,
                                 "GET", "/rest/api/2/search",
                                 params=params):
+
+            LOGGER.info(
+                "Fetched page %d with %d issues for project %s",
+                page_index, len(page), project_key_or_id
+            )
             # sync comments and changelogs for each issue
             sync_sub_streams(page, issue_changelogs_updated)
             for issue in page:
@@ -467,16 +477,24 @@ class Issues(Stream):
 
             # Grab last_updated before transform in write_page
             last_updated = utils.strptime_to_utc(page[-1]["fields"]["updated"])
+            LOGGER.info("Writing issues for page %d, project %s...", page_index, project_key_or_id)
             with self.write_lock:
                 self.write_page(page)
 
                 Context.set_bookmark(page_num_offset, pager.next_page_num)
                 singer.write_state(Context.state)
+            
+            LOGGER.info("Finished writing issues for page %d, project %s", page_index, project_key_or_id)
+            page_index += 1
+        
+        # After the loop completes
         with self.write_lock:
             Context.set_bookmark(page_num_offset, None)
             Context.set_bookmark(updated_bookmark, last_updated)
             Context.set_bookmark(issue_changelogs_updated_bookmark_path, issue_changelogs_sync_time)
             singer.write_state(Context.state)
+
+        LOGGER.info('Done syncing project %s', project_key_or_id)
 
 
 class Worklogs(Stream):

--- a/tests/spec.py
+++ b/tests/spec.py
@@ -105,4 +105,8 @@ class TapSpec():
                 self.API_LIMIT: 0, # TODO: Backlog ticket to create data required to test this documentation says 1000, see https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-worklogs/#api-rest-api-2-worklog-updated-get
                 # https://stitchdata.atlassian.net/browse/SRCE-5193
             },
+            "worklogs_deleted": {
+                self.PRIMARY_KEYS: {"worklogId"},
+                self.API_LIMIT: 0,
+            }
         }

--- a/tests/spec.py
+++ b/tests/spec.py
@@ -74,6 +74,7 @@ class TapSpec():
 
         return {
             "projects": id_pk, # Tap uses deprecated all projects endpoint, not paginated one, see https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-projects/#api-group-projects
+            "projects_normalized": id_pk,
             "project_types": key_pk, # Not paginated, see https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-project-types/#api-rest-api-2-project-type-get
             "project_categories": id_pk, # Not paginated, see https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-project-categories/
             "versions": {


### PR DESCRIPTION
## Summary
- Pin `PyJWT>=2.2.0,<2.12.1` in setup.py to prevent pip from pulling PyJWT 2.12.1, which requires `typing_extensions` on Python <3.11
- Fixes MW-10972: all 191 Jira ingest jobs across 32 orgs were failing with `ModuleNotFoundError: No module named 'typing_extensions'`

## Root cause
`atlassian-jwt==3.0.0` declares `PyJWT>=2.2.0` with no upper bound. PyJWT 2.12.1 added `typing_extensions>=4.0` as a dependency for Python <3.11, but it wasn't being installed as a transitive dep in the Docker build. Since our executor image uses Python 3.9, every fresh build pulls the broken version.

## Test plan
- [ ] Merge and update the git SHA in `scheduled/Dockerfile` to point to the new commit
- [ ] Deploy scheduled and verify Jira ingest jobs succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)