### PR TITLE
SAC-30851: Adding visibility fields to fields_to_remove section

### DIFF
--- a/tests/test_all_fields.py
+++ b/tests/test_all_fields.py
@@ -13,7 +13,8 @@ class AllFieldsTest(BaseTapTest):
     fields_to_remove = {
         # Most of the fields will be included using "expand" parameter in the API Call
         # See backlog card: https://jira.talendforge.org/browse/TDL-17948 for more details
-        "worklogs": ["properties"],
+        # visibility: only present when a worklog has a visibility restriction set
+        "worklogs": ["properties", "visibility"],
         # removed in the Tap
         "project_types": ["icon"],
         # name, key: properties are deprected
@@ -23,7 +24,7 @@ class AllFieldsTest(BaseTapTest):
         "versions": ["expand", "moveUnfixedIssuesTo", "project", "remotelinks", "operations"],
         # fieldsToInclude: not found in the doc
         "issues": ["renderedFields", "schema", "editmeta", "fieldsToInclude", "versionedRepresentations", "names", "properties"],
-        "issue_comments": ["properties", "renderedBody"],
+        "issue_comments": ["properties", "renderedBody", "visibility"],
         "projects": ["roles", "issueTypes", "email", "assigneeType", "components"],
         "issue_transitions": ["fields", "expand"],
         # iconUrl: not found in the doc


### PR DESCRIPTION
# Description of change
JIRA: https://qlik-dev.atlassian.net/browse/SAC-30851

**Changes:**

- Adding the visibility field to fields_to_remove section for streams _worklogs_ and _issue_comments_ as this field is returned conditionally by the API only when there's a restriction set explicitly .

Note: Possible reason why this wasnt the case before is that it might have had a worklog with a visibility restriction already present (from manual setup or leftover data), masking the issue.

**Checks:**
- [x] Local run automated tests
