### PR TITLE
Ignore missing updated in issues record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v2.8.1]
+  * Ignore missing `updated` field in issues record [#138](https://github.com/singer-io/tap-jira/pull/138)
+
 ## [v2.8.0]
   * Bump singer-python and requests modules to latest version. [#136](https://github.com/singer-io/tap-jira/pull/136)
   * Add visibility fields to fields_to_remove section. [#137](https://github.com/singer-io/tap-jira/pull/137)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## [v2.8.1]
-  * Ignore missing `updated` field in issues record [#138](https://github.com/singer-io/tap-jira/pull/138)
+  * Handle missing `updated` field in issues records to prevent sync failures when Jira API omits the field from some records. [#138](https://github.com/singer-io/tap-jira/pull/138)
 
 ## [v2.8.0]
   * Bump singer-python and requests modules to latest version. [#136](https://github.com/singer-io/tap-jira/pull/136)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="tap-jira",
-      version="2.8.0",
+      version="2.8.1",
       description="Singer.io tap for extracting data from the Jira API",
       author="Stitch",
       url="http://singer.io",

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -375,8 +375,10 @@ class Issues(Stream):
                 # so we decided to just strip the field out for now.
                 issue['fields'].pop('operations', None)
 
-            # Grab last_updated before transform in write_page
-            last_updated = utils.strptime_to_utc(page[-1]["fields"]["updated"])
+                _updated = issue.get("fields", {}).get("updated")
+                if _updated:
+                    last_updated = utils.strptime_to_utc(_updated)
+
             self.write_page(page)
             Context.set_bookmark(page_num_offset, pager.next_page_num)
             # Copy parent's bookmark to children


### PR DESCRIPTION
# Description of change
`updated` is basically replication key for issue stream and ideally every records should contain `non null` value for that field. But, it seems Jira API itself not returning updated field in the response for some of the records. 

To handle this unexpected situation, I have added logic to ignore missing updated field instead of throwing error and blocking further sync progress.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
